### PR TITLE
Example Java8 method reference usage

### DIFF
--- a/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/SimpleApplication.java
+++ b/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/SimpleApplication.java
@@ -12,16 +12,17 @@
  */
 package ro.fortsoft.pippo.demo;
 
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
 import ro.fortsoft.pippo.core.Application;
 import ro.fortsoft.pippo.core.Request;
 import ro.fortsoft.pippo.core.Response;
 import ro.fortsoft.pippo.core.route.RouteHandler;
 import ro.fortsoft.pippo.core.route.RouteHandlerChain;
+import ro.fortsoft.pippo.demo.controller.J8Controller;
 import ro.fortsoft.pippo.demo.crud.Contact;
-
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author Decebal Suiu
@@ -41,6 +42,16 @@ public class SimpleApplication extends Application {
             }
 
         });
+
+        // Java8 static lambda to J8Controller which is NOT a RouteHandler.
+        // This approach takes advantage of the fixed arguments (Request, Response, RouteHandlerChain).
+        // Note that J8Controller is not a RouteHandler.
+        GET("/hello1", J8Controller::helloStatic);
+
+        // This one would be ideal, but it requires adopting Java8 in Pippo
+        // GET("/hello2a", J8Controller::hello);
+
+        GET("/hello2b", new J8Controller()::hello);
 
         // send a file as response
         GET("/file", new RouteHandler() {

--- a/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/controller/J8Controller.java
+++ b/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/controller/J8Controller.java
@@ -1,0 +1,23 @@
+package ro.fortsoft.pippo.demo.controller;
+
+import ro.fortsoft.pippo.core.Request;
+import ro.fortsoft.pippo.core.Response;
+import ro.fortsoft.pippo.core.route.RouteHandlerChain;
+
+/**
+ * Sample controller methods.
+ *
+ * @author James Moger
+ *
+ */
+public class J8Controller {
+
+    public static void helloStatic(Request request, Response response, RouteHandlerChain chain) {
+        response.send("Hello World");
+    }
+
+    public void hello(Request request, Response response, RouteHandlerChain chain) {
+        response.send("Hello World");
+    }
+
+}


### PR DESCRIPTION
Hi Decebal,

This is some example code which works with stock Pippo if you are running Java 8 and demonstrates what I meant.  The commented out approach would be ideal, I think.  I know you want to stay on a Java 7 base, but consider the ramp-up time for a web framework to gain traction and then consider that Oracle ends support for Java 7 within the next 6-12 months.  JRE8 is now the default runtime on java.com.  Long-term it might make more sense to adopt J8 as a base.  Just my thoughts.  :smile: 

This is just a throw-away PR, not for merging.

http://baddotrobot.com/blog/2014/02/18/method-references-in-java8/
