### PR TITLE
Add an optional Java 8+ controller handler to use compiled parameter names

### DIFF
--- a/pippo-parameterized-controllers/pom.xml
+++ b/pippo-parameterized-controllers/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<parent>
+		<groupId>ro.fortsoft.pippo</groupId>
+		<artifactId>pippo-parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+	<packaging>jar</packaging>
+	<artifactId>pippo-parameterized-controllers</artifactId>
+	<version>0.4.0-SNAPSHOT</version>
+	<name>Pippo Parameterized Controllers</name>
+	<description>A controller handler which will map controller method parameter  names to request parameters.
+
+Requires Java8 or newer and compilation with parameter metadata.</description>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<compilerArguments>
+						<parameters />
+					</compilerArguments>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>ro.fortsoft.pippo</groupId>
+			<artifactId>pippo-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/pippo-parameterized-controllers/src/main/java/ro/fortsoft/pippo/core/controller/ParameterizedControllerHandler.java
+++ b/pippo-parameterized-controllers/src/main/java/ro/fortsoft/pippo/core/controller/ParameterizedControllerHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pippo.core.controller;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+import ro.fortsoft.pippo.core.util.StringUtils;
+
+/**
+ * A {@link ControllerHandler} that will try to use Java 8+ compiled parameter
+ * names if the {@link DefaultControllerHandler} can not identify a name for the
+ * method parameter.
+ * <p>
+ * This handler is only effective if you are compiling with the javac
+ * <code>-parameters</code> flag.
+ * </p>
+ *
+ * @author James Moger
+ */
+public class ParameterizedControllerHandler extends DefaultControllerHandler {
+
+    public ParameterizedControllerHandler(Class<? extends Controller> controllerClass, String methodName) {
+        super(controllerClass, methodName);
+    }
+
+    @Override
+    protected String getParameterName(Method method, int i) {
+
+        String name = super.getParameterName(method, i);
+
+        if (StringUtils.isNullOrEmpty(name)) {
+            // parameter is not named via annotation
+            // try looking for the parameter name in the compiled .class file
+            Parameter parameter = method.getParameters()[i];
+            if (parameter.isNamePresent()) {
+                name = parameter.getName();
+            }
+        }
+
+        return name;
+    }
+
+}

--- a/pippo-parameterized-controllers/src/main/java/ro/fortsoft/pippo/core/controller/ParameterizedControllerHandlerFactory.java
+++ b/pippo-parameterized-controllers/src/main/java/ro/fortsoft/pippo/core/controller/ParameterizedControllerHandlerFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pippo.core.controller;
+
+import ro.fortsoft.pippo.core.Application;
+import ro.fortsoft.pippo.core.route.RouteHandler;
+
+/**
+ * This factory constructs the named arguments controller handler.
+ *
+ * @author James Moger
+ *
+ */
+public class ParameterizedControllerHandlerFactory implements ControllerHandlerFactory {
+
+    @Override
+    public RouteHandler createHandler(Class<? extends Controller> controllerClass, String methodName) {
+        return new ParameterizedControllerHandler(controllerClass, methodName);
+    }
+
+    @Override
+    public void init(Application application) {
+    }
+
+    @Override
+    public void destroy(Application application) {
+    }
+}

--- a/pippo-parameterized-controllers/src/main/resources/META-INF/services/ro.fortsoft.pippo.core.controller.ControllerHandlerFactory
+++ b/pippo-parameterized-controllers/src/main/resources/META-INF/services/ro.fortsoft.pippo.core.controller.ControllerHandlerFactory
@@ -1,0 +1,1 @@
+ro.fortsoft.pippo.core.controller.ParameterizedControllerHandlerFactory

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <module>pippo-metrics-graphite</module>
         <module>pippo-metrics-influxdb</module>
         <module>pippo-metrics-librato</module>
+        <module>pippo-parameterized-controllers</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Now that we've merged #42, a Java8+ ControllerHandler becomes basically this:

```java
   @Override
    protected String getParameterName(Method method, int i) {

        String name = super.getParameterName(method, i);

        if (StringUtils.isNullOrEmpty(name)) {
            // parameter is not named via annotation
            // try looking for the parameter name in the compiled .class file
            Parameter parameter = method.getParameters()[i];
            if (parameter.isNamePresent()) {
                name = parameter.getName();
            }
        }

        return name;
    }
```

I am struggling to name this module and I'm not sure if you will agree to merge an optional Java8 module anyway.  Suggestions or feedback welcome.