### PR TITLE
Expose all WebServerSettings to application.properties and add external files path

### DIFF
--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/PippoConstants.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/PippoConstants.java
@@ -53,6 +53,8 @@ public final class PippoConstants {
 
     public static final String SETTING_SERVER_CONTEXT_PATH = "server.contextPath";
 
+    public static final String SETTING_SERVER_EXTERNAL_FILES_PATH = "server.externalFilesPath";
+
     public static final String SETTING_SERVER_EXTERNAL_FILES_LOCATION = "server.externalFilesLocation";
 
     public static final String SETTING_SERVER_KEYSTORE_FILE = "server.keystoreFile";

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/PippoConstants.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/PippoConstants.java
@@ -53,6 +53,16 @@ public final class PippoConstants {
 
     public static final String SETTING_SERVER_CONTEXT_PATH = "server.contextPath";
 
+    public static final String SETTING_SERVER_EXTERNAL_FILES_LOCATION = "server.externalFilesLocation";
+
+    public static final String SETTING_SERVER_KEYSTORE_FILE = "server.keystoreFile";
+
+    public static final String SETTING_SERVER_KEYSTORE_PASSWORD = "server.keystorePassword";
+
+    public static final String SETTING_SERVER_TRUSTSTORE_FILE = "server.truststoreFile";
+
+    public static final String SETTING_SERVER_TRUSTSTORE_PASSWORD = "server.truststorePassword";
+
     public static final String REQUEST_PARAMETER_LANG = "lang";
 
     public static final String REQUEST_PARAMETER_LOCALE = "locale";

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/WebServerSettings.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/WebServerSettings.java
@@ -42,6 +42,11 @@ public class WebServerSettings implements Serializable {
         this.port = pippoSettings.getInteger(PippoConstants.SETTING_SERVER_PORT, defaultPort);
         this.host = pippoSettings.getString(PippoConstants.SETTING_SERVER_HOST, host);
         this.contextPath = pippoSettings.getString(PippoConstants.SETTING_SERVER_CONTEXT_PATH, contextPath);
+        this.externalStaticFilesLocation = pippoSettings.getString(PippoConstants.SETTING_SERVER_EXTERNAL_FILES_LOCATION, externalStaticFilesLocation);
+        this.keystoreFile = pippoSettings.getString(PippoConstants.SETTING_SERVER_KEYSTORE_FILE, keystoreFile);
+        this.keystorePassword = pippoSettings.getString(PippoConstants.SETTING_SERVER_KEYSTORE_PASSWORD, keystorePassword);
+        this.truststoreFile = pippoSettings.getString(PippoConstants.SETTING_SERVER_TRUSTSTORE_FILE, truststoreFile);
+        this.truststorePassword = pippoSettings.getString(PippoConstants.SETTING_SERVER_TRUSTSTORE_PASSWORD, truststorePassword);
     }
 
     public String getHost() {

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/WebServerSettings.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/WebServerSettings.java
@@ -29,6 +29,7 @@ public class WebServerSettings implements Serializable {
     private String host = "localhost";
     private int port = defaultPort;
     private String contextPath = "/";
+    private String externalStaticFilesPath = "/ext";
     private String externalStaticFilesLocation;
     private String keystoreFile;
     private String keystorePassword;
@@ -42,6 +43,7 @@ public class WebServerSettings implements Serializable {
         this.port = pippoSettings.getInteger(PippoConstants.SETTING_SERVER_PORT, defaultPort);
         this.host = pippoSettings.getString(PippoConstants.SETTING_SERVER_HOST, host);
         this.contextPath = pippoSettings.getString(PippoConstants.SETTING_SERVER_CONTEXT_PATH, contextPath);
+        this.externalStaticFilesPath = pippoSettings.getString(PippoConstants.SETTING_SERVER_EXTERNAL_FILES_PATH, externalStaticFilesPath);
         this.externalStaticFilesLocation = pippoSettings.getString(PippoConstants.SETTING_SERVER_EXTERNAL_FILES_LOCATION, externalStaticFilesLocation);
         this.keystoreFile = pippoSettings.getString(PippoConstants.SETTING_SERVER_KEYSTORE_FILE, keystoreFile);
         this.keystorePassword = pippoSettings.getString(PippoConstants.SETTING_SERVER_KEYSTORE_PASSWORD, keystorePassword);
@@ -75,6 +77,16 @@ public class WebServerSettings implements Serializable {
 
     public WebServerSettings contextPath(String contextPath) {
         this.contextPath = contextPath;
+
+        return this;
+    }
+
+    public String getExternalStaticFilesPath() {
+        return externalStaticFilesPath;
+    }
+
+    public WebServerSettings externalStaticFilesPath(String externalStaticFilesPath) {
+        this.externalStaticFilesPath = externalStaticFilesPath;
 
         return this;
     }

--- a/pippo-jetty/src/main/java/ro/fortsoft/pippo/jetty/JettyServer.java
+++ b/pippo-jetty/src/main/java/ro/fortsoft/pippo/jetty/JettyServer.java
@@ -30,6 +30,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
@@ -43,6 +44,7 @@ import ro.fortsoft.pippo.core.AbstractWebServer;
 import ro.fortsoft.pippo.core.HttpConstants;
 import ro.fortsoft.pippo.core.PippoRuntimeException;
 import ro.fortsoft.pippo.core.RuntimeMode;
+import ro.fortsoft.pippo.core.util.StringUtils;
 
 /**
  * @author Decebal Suiu
@@ -118,7 +120,13 @@ public class JettyServer extends AbstractWebServer {
         // add external static files handler
         Handler externalStaticResourceHandler = createExternalStaticResourceHandler();
         if (externalStaticResourceHandler != null) {
-            handlerList.addHandler(externalStaticResourceHandler);
+            String contextPath = StringUtils.addEnd(StringUtils.addStart(settings.getContextPath(), "/"), "/");
+            String extPath = StringUtils.removeStart(settings.getExternalStaticFilesPath(), "/");
+            String path = contextPath + extPath;
+
+            ContextHandler extHandler = new ContextHandler(path);
+            extHandler.setHandler(externalStaticResourceHandler);
+            handlerList.addHandler(extHandler);
         }
 
         // add pippo handler


### PR DESCRIPTION
This PR exposes all WebServerSettings to the `application.properties` file.  It also slightly revises the serving of external files.  External files are now served on a subpath of the context instead of co-mingling Pippo & external files directly on the context path. (i.e.  serve external files from `/context/ext` not `/context`).  The external files path is configurable via the API or `application.properties`.

Serving from multiple sources on the same exact path can create problems for other `WebServer` implementations.