### PR TITLE
RFC: Add Response.halt() to terminate the RouteHandlerChain

### DIFF
--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/DefaultErrorHandler.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/DefaultErrorHandler.java
@@ -117,7 +117,14 @@ public class DefaultErrorHandler implements ErrorHandler {
             response.bind("stacktrace", stackTrace);
         }
 
-        handle(HttpConstants.StatusCode.INTERNAL_ERROR, request, response);
+        // assume an internal error unless this is a HaltResponseException
+        int statusCode = HttpConstants.StatusCode.INTERNAL_ERROR;
+        if (exception instanceof HaltResponseException) {
+            HaltResponseException haltException = (HaltResponseException) exception;
+            statusCode = haltException.getStatusCode();
+        }
+
+        handle(statusCode, request, response);
     }
 
     /**

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/HaltResponseException.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/HaltResponseException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pippo.core;
+
+/**
+ * @author James Moger
+ */
+public class HaltResponseException extends PippoRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int statusCode;
+
+    public HaltResponseException(int statusCode, String message, Object... parameters) {
+        super(format(message, parameters));
+
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/PippoFilter.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/PippoFilter.java
@@ -181,7 +181,13 @@ public class PippoFilter implements Filter {
                 }
             }
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            if (e instanceof HaltResponseException) {
+                // normal response, log the message and status code
+                HaltResponseException haltException = (HaltResponseException) e;
+                log.debug("Halt '{}' ({})", haltException.getMessage(), haltException.getStatusCode());
+            } else {
+                log.error(e.getMessage(), e);
+            }
             ErrorHandler errorHandler = application.getErrorHandler();
             if (errorHandler != null) {
                 if (!response.isCommitted()) {

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/Response.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/Response.java
@@ -545,6 +545,14 @@ public class Response {
         getCookieMap().put(cookie.getName(), cookie);
     }
 
+    public void halt(int statusCode) {
+        throw new HaltResponseException(statusCode, null);
+    }
+
+    public void halt(int statusCode, String message, Object... args) {
+        throw new HaltResponseException(statusCode, message, args);
+    }
+
     public void commit() {
         // add cookies
         for (Cookie cookie : getCookies()) {

--- a/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/SimpleApplication.java
+++ b/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/SimpleApplication.java
@@ -16,6 +16,7 @@
 package ro.fortsoft.pippo.demo;
 
 import ro.fortsoft.pippo.core.Application;
+import ro.fortsoft.pippo.core.HttpConstants;
 import ro.fortsoft.pippo.core.Request;
 import ro.fortsoft.pippo.core.Response;
 import ro.fortsoft.pippo.core.route.RouteHandler;
@@ -133,6 +134,16 @@ public class SimpleApplication extends Application {
             @Override
             public void handle(Request request, Response response, RouteHandlerChain chain) {
                 throw new RuntimeException("Error");
+            }
+
+        });
+
+        // halt a response
+        GET("/halt", new RouteHandler() {
+
+            @Override
+            public void handle(Request request, Response response, RouteHandlerChain chain) {
+                response.contentType(HttpConstants.ContentType.APPLICATION_XML).halt(HttpConstants.StatusCode.NOT_FOUND, "You halted the response");
             }
 
         });


### PR DESCRIPTION
Here is a `halt()` implementation that lets the `ErrorHandler` deal with the situation.  That's probably not right but it highlights what I think is a problem with the `Response` mechanism.  All the `send()` methods are suspect too - anything that commits from `Response`.

If you are writing API handlers you likely want them to return a `Result` object with a status code and an optional message.  Not all of those results are errors, but some are.  For example maybe I want to return:

```java
response.xml().negotiate(request).sendOk("Saved {}", contact.getId());
```

BUT still close my open DB connection in the filter that should execute afterwards.  I recognize that will work today, but are we allowing people to break stuff by committing within the chain and not warning/failing afterwards.  It would be painful to call `checkCommitted()` for every possible setter.  In the filter that closes the DB I can set a header which will not be sent to the client because the response was committed in `sendOk`.

I'm open to suggestions on improving this.  I think we should consider following Spark's request processing loop.  I also think we need to consider a `Result` class which is returned for unspecified bodies or something like that.