### PR TITLE
RFC: Add factories for Request and Response

### DIFF
--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/DefaultRequestFactory.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/DefaultRequestFactory.java
@@ -23,7 +23,7 @@ import javax.servlet.http.HttpServletRequest;
  * @author James Moger
  *
  */
-public class DefaultRequestFactory implements RequestFactory {
+public class DefaultRequestFactory implements RequestFactory<Request> {
 
     @Override
     public Request createRequest(HttpServletRequest httpServletRequest, Application application) {

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/DefaultRequestFactory.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/DefaultRequestFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pippo.core;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This factory constructs the Pippo default Request class.
+ *
+ * @author James Moger
+ *
+ */
+public class DefaultRequestFactory implements RequestFactory {
+
+    @Override
+    public Request createRequest(HttpServletRequest httpServletRequest, Application application) {
+        return new Request(httpServletRequest, application);
+    }
+
+    @Override
+    public void init(Application application) {
+    }
+
+    @Override
+    public void destroy(Application application) {
+    }
+}

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/DefaultResponseFactory.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/DefaultResponseFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pippo.core;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * This factory constructs the Pippo default Response class.
+ *
+ * @author James Moger
+ */
+public class DefaultResponseFactory implements ResponseFactory {
+
+    @Override
+    public Response createResponse(HttpServletResponse httpServletResponse, Application application) {
+        return new Response(httpServletResponse, application);
+    }
+
+    @Override
+    public void init(Application application) {
+    }
+
+    @Override
+    public void destroy(Application application) {
+    }
+}

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/DefaultResponseFactory.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/DefaultResponseFactory.java
@@ -22,7 +22,7 @@ import javax.servlet.http.HttpServletResponse;
  *
  * @author James Moger
  */
-public class DefaultResponseFactory implements ResponseFactory {
+public class DefaultResponseFactory implements ResponseFactory<Response> {
 
     @Override
     public Response createResponse(HttpServletResponse httpServletResponse, Application application) {

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/Request.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/Request.java
@@ -57,7 +57,7 @@ public class Request {
 
     private String body; // cache
 
-    Request(HttpServletRequest servletRequest, Application application) {
+    protected Request(HttpServletRequest servletRequest, Application application) {
         this.httpServletRequest = servletRequest;
         this.contentTypeEngines = application.getContentTypeEngines();
 

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/RequestFactory.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/RequestFactory.java
@@ -20,7 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * @author James Moger
  */
-public interface RequestFactory extends Initializer {
+public interface RequestFactory<T extends Request> extends Initializer {
 
-    public Request createRequest(HttpServletRequest httpServletRequest, Application application);
+    public T createRequest(HttpServletRequest httpServletRequest, Application application);
 }

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/RequestFactory.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/RequestFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pippo.core;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author James Moger
+ */
+public interface RequestFactory extends Initializer {
+
+    public Request createRequest(HttpServletRequest httpServletRequest, Application application);
+}

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/Response.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/Response.java
@@ -49,7 +49,7 @@ public class Response {
     private Map<String, Cookie> cookies;
     private String contextPath;
 
-    Response(HttpServletResponse httpServletResponse, Application application) {
+    protected Response(HttpServletResponse httpServletResponse, Application application) {
         this.httpServletResponse = httpServletResponse;
         this.contentTypeEngines = application.getContentTypeEngines();
         this.templateEngine = application.getTemplateEngine();

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/ResponseFactory.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/ResponseFactory.java
@@ -20,7 +20,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * @author James Moger
  */
-public interface ResponseFactory extends Initializer {
+public interface ResponseFactory<T extends Response> extends Initializer {
 
-    public Response createResponse(HttpServletResponse httpServletResponse, Application application);
+    public T createResponse(HttpServletResponse httpServletResponse, Application application);
 }

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/ResponseFactory.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/ResponseFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pippo.core;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author James Moger
+ */
+public interface ResponseFactory extends Initializer {
+
+    public Response createResponse(HttpServletResponse httpServletResponse, Application application);
+}

--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/route/RouteHandler.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/route/RouteHandler.java
@@ -21,8 +21,8 @@ import ro.fortsoft.pippo.core.Response;
 /**
  * @author Decebal Suiu
  */
-public interface RouteHandler {
+public interface RouteHandler<A extends Request, B extends Response> {
 
-    public void handle(Request request, Response response, RouteHandlerChain chain);
+    public void handle(A request, B response, RouteHandlerChain chain);
 
 }

--- a/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomHandler.java
+++ b/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomHandler.java
@@ -15,20 +15,10 @@
  */
 package ro.fortsoft.pippo.demo;
 
-import ro.fortsoft.pippo.core.Request;
-import ro.fortsoft.pippo.core.Response;
 import ro.fortsoft.pippo.core.route.RouteHandler;
-import ro.fortsoft.pippo.core.route.RouteHandlerChain;
 
 /**
  * @author James Moger
  */
-public abstract class CustomHandler implements RouteHandler {
-
-    @Override
-    public void handle(Request request, Response response, RouteHandlerChain chain) {
-        handle((CustomRequest) request, (CustomResponse) response, chain);
-    }
-
-    public abstract void handle(CustomRequest request, CustomResponse response, RouteHandlerChain chain);
+public interface CustomHandler extends RouteHandler<CustomRequest, CustomResponse> {
 }

--- a/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomHandler.java
+++ b/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pippo.demo;
+
+import ro.fortsoft.pippo.core.Request;
+import ro.fortsoft.pippo.core.Response;
+import ro.fortsoft.pippo.core.route.RouteHandler;
+import ro.fortsoft.pippo.core.route.RouteHandlerChain;
+
+/**
+ * @author James Moger
+ */
+public abstract class CustomHandler implements RouteHandler {
+
+    @Override
+    public void handle(Request request, Response response, RouteHandlerChain chain) {
+        handle((CustomRequest) request, (CustomResponse) response, chain);
+    }
+
+    public abstract void handle(CustomRequest request, CustomResponse response, RouteHandlerChain chain);
+}

--- a/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomRequest.java
+++ b/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pippo.demo;
+
+import ro.fortsoft.pippo.core.Application;
+import ro.fortsoft.pippo.core.HttpConstants;
+import ro.fortsoft.pippo.core.Request;
+import ro.fortsoft.pippo.core.Response;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author James Moger
+ */
+public class CustomRequest extends Request {
+
+    protected CustomRequest(HttpServletRequest httpServletRequest, Application application) {
+        super(httpServletRequest, application);
+    }
+
+}

--- a/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomRequestFactory.java
+++ b/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomRequestFactory.java
@@ -18,17 +18,16 @@ package ro.fortsoft.pippo.demo;
 import ro.fortsoft.pippo.core.*;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * This class constructs a CustomRequest to be passed to all handlers.
  *
  * @author James Moger
  */
-public class CustomRequestFactory implements RequestFactory {
+public class CustomRequestFactory implements RequestFactory<CustomRequest> {
 
     @Override
-    public Request createRequest(HttpServletRequest httpServletRequest, Application application) {
+    public CustomRequest createRequest(HttpServletRequest httpServletRequest, Application application) {
         return new CustomRequest(httpServletRequest, application);
     }
 

--- a/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomRequestFactory.java
+++ b/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomRequestFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pippo.demo;
+
+import ro.fortsoft.pippo.core.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * This class constructs a CustomRequest to be passed to all handlers.
+ *
+ * @author James Moger
+ */
+public class CustomRequestFactory implements RequestFactory {
+
+    @Override
+    public Request createRequest(HttpServletRequest httpServletRequest, Application application) {
+        return new CustomRequest(httpServletRequest, application);
+    }
+
+    @Override
+    public void init(Application application) {
+
+    }
+
+    @Override
+    public void destroy(Application application) {
+
+    }
+}

--- a/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomResponse.java
+++ b/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pippo.demo;
+
+import ro.fortsoft.pippo.core.Application;
+import ro.fortsoft.pippo.core.HttpConstants;
+import ro.fortsoft.pippo.core.Response;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author James Moger
+ */
+public class CustomResponse extends Response {
+
+    protected CustomResponse(HttpServletResponse httpServletResponse, Application application) {
+        super(httpServletResponse, application);
+    }
+
+    public void sendHelloMyFriend() {
+        status(HttpConstants.StatusCode.OK).text().send("Hello, my friend!");
+    }
+}

--- a/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomResponseFactory.java
+++ b/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomResponseFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pippo.demo;
+
+import ro.fortsoft.pippo.core.Application;
+import ro.fortsoft.pippo.core.Response;
+import ro.fortsoft.pippo.core.ResponseFactory;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * This class constructs a CustomResponse to be passed to all handlers.
+ *
+ * @author James Moger
+ */
+public class CustomResponseFactory implements ResponseFactory {
+
+    @Override
+    public Response createResponse(HttpServletResponse httpServletResponse, Application application) {
+        return new CustomResponse(httpServletResponse, application);
+    }
+
+    @Override
+    public void init(Application application) {
+
+    }
+
+    @Override
+    public void destroy(Application application) {
+
+    }
+}

--- a/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomResponseFactory.java
+++ b/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/CustomResponseFactory.java
@@ -16,7 +16,6 @@
 package ro.fortsoft.pippo.demo;
 
 import ro.fortsoft.pippo.core.Application;
-import ro.fortsoft.pippo.core.Response;
 import ro.fortsoft.pippo.core.ResponseFactory;
 
 import javax.servlet.http.HttpServletResponse;
@@ -26,10 +25,10 @@ import javax.servlet.http.HttpServletResponse;
  *
  * @author James Moger
  */
-public class CustomResponseFactory implements ResponseFactory {
+public class CustomResponseFactory implements ResponseFactory<CustomResponse> {
 
     @Override
-    public Response createResponse(HttpServletResponse httpServletResponse, Application application) {
+    public CustomResponse createResponse(HttpServletResponse httpServletResponse, Application application) {
         return new CustomResponse(httpServletResponse, application);
     }
 

--- a/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/SimpleApplication.java
+++ b/pippo-demo/src/main/java/ro/fortsoft/pippo/demo/SimpleApplication.java
@@ -152,6 +152,17 @@ public class SimpleApplication extends Application {
             }
 
         });
+
+        // use custom Request and Response types
+        GET("/hello", new CustomHandler() {
+
+            @Override
+            public void handle(CustomRequest request, CustomResponse response, RouteHandlerChain chain) {
+
+                response.sendHelloMyFriend();
+            }
+
+        });
     }
 
 }

--- a/pippo-demo/src/main/resources/META-INF/services/ro.fortsoft.pippo.core.RequestFactory
+++ b/pippo-demo/src/main/resources/META-INF/services/ro.fortsoft.pippo.core.RequestFactory
@@ -1,0 +1,1 @@
+ro.fortsoft.pippo.demo.CustomRequestFactory

--- a/pippo-demo/src/main/resources/META-INF/services/ro.fortsoft.pippo.core.ResponseFactory
+++ b/pippo-demo/src/main/resources/META-INF/services/ro.fortsoft.pippo.core.ResponseFactory
@@ -1,0 +1,1 @@
+ro.fortsoft.pippo.demo.CustomResponseFactory


### PR DESCRIPTION
This allows consumers of Pippo to implement higher level RouteHandlers which contain domain-specific logic such as object serialization/deserialization, etc.