### PR TITLE
Fix https://github.com/decebals/pippo/issues/70 to check if not contentt...

### DIFF
--- a/pippo-core/src/main/java/ro/fortsoft/pippo/core/Response.java
+++ b/pippo-core/src/main/java/ro/fortsoft/pippo/core/Response.java
@@ -576,7 +576,7 @@ public class Response {
     public void resource(InputStream input) {
         checkCommitted();
 
-        if (isHeaderEmpty(HttpConstants.Header.CONTENT_TYPE)) {
+        if (isHeaderEmpty(HttpConstants.Header.CONTENT_TYPE) && getHttpServletResponse().getContentType() == null) {
             header(HttpConstants.Header.CONTENT_TYPE, HttpConstants.ContentType.APPLICATION_OCTET_STREAM);
         }
 
@@ -670,7 +670,7 @@ public class Response {
 
     private boolean isHeaderEmpty(String name) {
         String value = getHttpServletResponse().getHeader(name);
-        return (value == null) || value.isEmpty();
+        return StringUtils.isNullOrEmpty(value);
     }
 
     private void checkCommitted() {


### PR DESCRIPTION
...ype was not already set on the response before we overwritte the header instead of letting the container handle it.