### PR TITLE
add StaticResourceHandle

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/Application.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Application.java
@@ -21,8 +21,8 @@ import ro.pippo.core.controller.ControllerInitializationListenerList;
 import ro.pippo.core.controller.ControllerInstantiationListenerList;
 import ro.pippo.core.controller.ControllerInvokeListenerList;
 import ro.pippo.core.controller.DefaultControllerHandlerFactory;
-import ro.pippo.core.route.ClasspathResourceHandler;
 import ro.pippo.core.route.DefaultRouter;
+import ro.pippo.core.route.StaticResourceHandler;
 import ro.pippo.core.route.Route;
 import ro.pippo.core.route.RouteHandler;
 import ro.pippo.core.route.Router;
@@ -202,7 +202,7 @@ public class Application {
         getRouter().setContextPath(contextPath);
     }
 
-    public void GET(ClasspathResourceHandler resourceHandler) {
+    public void GET(StaticResourceHandler resourceHandler) {
         if (getRouter().uriPatternFor(resourceHandler.getClass()) != null) {
             throw new PippoRuntimeException("You may only register one route for {}",
                     resourceHandler.getClass().getSimpleName());

--- a/pippo-core/src/main/java/ro/pippo/core/Response.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Response.java
@@ -794,6 +794,11 @@ public class Response {
     public void resource(InputStream input) {
         checkCommitted();
 
+        // add cookies
+        for (Cookie cookie : getCookies()) {
+            httpServletResponse.addCookie(cookie);
+        }
+
         // content type to OCTET_STREAM if it's not set
         if (getContentType() == null) {
             contentType(HttpConstants.ContentType.APPLICATION_OCTET_STREAM);
@@ -805,7 +810,10 @@ public class Response {
                 contentLength(length);
             }
 
-            commit();
+            // by calling httpServletResponse.getOutputStream() we have already
+            // committed the response
+            httpServletResponse.flushBuffer();
+
         } catch (Exception e) {
             throw new PippoRuntimeException(e);
         } finally {
@@ -837,6 +845,11 @@ public class Response {
     public void file(String filename, InputStream input) {
         checkCommitted();
 
+        // add cookies
+        for (Cookie cookie : getCookies()) {
+            httpServletResponse.addCookie(cookie);
+        }
+
         // content type to OCTET_STREAM if it's not set
         if (getContentType() == null) {
             contentType(HttpConstants.ContentType.APPLICATION_OCTET_STREAM);
@@ -856,7 +869,10 @@ public class Response {
                 contentLength(length);
             }
 
-            commit();
+            // by calling httpServletResponse.getOutputStream() we have already
+            // committed the response
+            httpServletResponse.flushBuffer();
+
         } catch (Exception e) {
             throw new PippoRuntimeException(e);
         } finally {
@@ -933,6 +949,7 @@ public class Response {
         }
 
         try {
+            log.debug("Response committed");
             httpServletResponse.flushBuffer();
         } catch (IOException e) {
             throw new PippoRuntimeException(e);

--- a/pippo-core/src/main/java/ro/pippo/core/route/ClasspathResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/ClasspathResourceHandler.java
@@ -15,121 +15,22 @@
  */
 package ro.pippo.core.route;
 
-import ro.pippo.core.HttpConstants;
-import ro.pippo.core.PippoRuntimeException;
-import ro.pippo.core.Request;
-import ro.pippo.core.Response;
-import ro.pippo.core.util.HttpCacheToolkit;
-import ro.pippo.core.util.MimeTypes;
-import ro.pippo.core.util.StringUtils;
-
 import java.net.URL;
-import java.net.URLConnection;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Serves classpath resources.
  *
  * @author James Moger
  */
-public class ClasspathResourceHandler implements RouteHandler {
-
-    private static final Logger log = LoggerFactory.getLogger(ClasspathResourceHandler.class);
-
-    public static String PATH_PARAMETER = "path";
-
-    private final String uriPattern;
-    private final String resourceBasePath;
-
-    private MimeTypes mimeTypes;
-
-    private HttpCacheToolkit httpCacheToolkit;
+public class ClasspathResourceHandler extends StaticResourceHandler {
 
     public ClasspathResourceHandler(String urlPath, String resourceBasePath) {
-        this.uriPattern = String.format("/%s/{%s: .*}", getNormalizedPath(urlPath), PATH_PARAMETER);
-        this.resourceBasePath = getNormalizedPath(resourceBasePath);
-    }
-
-    public String getUriPattern() {
-        return uriPattern;
-    }
-
-    public void setMimeTypes(MimeTypes mimeTypes) {
-        this.mimeTypes = mimeTypes;
-    }
-
-    public void setHttpCacheToolkit(HttpCacheToolkit httpCacheToolkit) {
-        this.httpCacheToolkit = httpCacheToolkit;
+        super(urlPath, resourceBasePath);
     }
 
     @Override
-    public void handle(Request request, Response response, RouteHandlerChain chain) {
-        String path = getRequestedPath(request);
-        log.debug("Request for '{}'", path);
-
-        URL url = this.getClass().getClassLoader().getResource(path);
-        if (url == null) {
-            response.notFound().commit();
-        } else {
-            streamClasspathResource(url, request, response);
-        }
-
-        chain.next();
-    }
-
-    protected String getRequestedPath(Request request) {
-        String path = request.getParameter(PATH_PARAMETER).toString();
-        String normalizedPath = getNormalizedPath(path);
-        return resourceBasePath + "/" + normalizedPath;
-    }
-
-    protected String getNormalizedPath(String path) {
-        if ('/' == path.charAt(0)) {
-            path = path.substring(1);
-        }
-        if ('/' == path.charAt(path.length() - 1)) {
-            path = path.substring(0, path.length() - 1);
-        }
-
-        return path;
-    }
-
-    protected String getFilename(String path) {
-        return path.substring(path.lastIndexOf('/') + 1);
-    }
-
-    protected void streamClasspathResource(URL url, Request request, Response response) {
-        try {
-            URLConnection urlConnection = url.openConnection();
-            long lastModified = urlConnection.getLastModified();
-            httpCacheToolkit.addEtag(request, response, lastModified);
-
-            if (response.getStatus() == HttpConstants.StatusCode.NOT_MODIFIED) {
-                // Do not stream anything out. Simply return 304
-                log.debug("Unmodified resource '{}'", url);
-                response.commit();
-            } else {
-                String filename = url.getFile();
-
-                // Try to set the mimetype:
-                String mimeType = mimeTypes.getContentType(request, response, filename);
-
-                if (!StringUtils.isNullOrEmpty(mimeType)) {
-                    // stream the resource
-                    log.debug("Streaming as resource '{}'", url);
-                    response.contentType(mimeType);
-                    response.resource(urlConnection.getInputStream());
-                } else {
-                    // stream the file
-                    log.debug("Streaming as file '{}'", url);
-                    response.file(filename, urlConnection.getInputStream());
-                }
-            }
-        } catch (Exception e) {
-            throw new PippoRuntimeException("Failed to stream classpath resource " + url, e);
-        }
+    public URL getResourceUrl(String resourcePath) {
+        return this.getClass().getClassLoader().getResource(getResourceBasePath() + "/" + resourcePath);
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -215,13 +215,13 @@ public class DefaultRouter implements Router {
     }
 
     @Override
-    public String uriPatternFor(Class<? extends ClasspathResourceHandler> resourceHandlerClass) {
+    public String uriPatternFor(Class<? extends StaticResourceHandler> resourceHandlerClass) {
         Route route = getRoute(resourceHandlerClass);
 
         return (route != null) ? route.getUriPattern() : null;
     }
 
-    private Route getRoute(Class<? extends ClasspathResourceHandler> resourceHandlerClass) {
+    private Route getRoute(Class<? extends StaticResourceHandler> resourceHandlerClass) {
         List<Route> routes = getRoutes();
         for (Route route : routes) {
             RouteHandler routeHandler = route.getRouteHandler();
@@ -293,10 +293,9 @@ public class DefaultRouter implements Router {
      *          specified by the user.
      */
     private String getRegex(String urlPattern) {
+        StringBuffer buffer = new StringBuffer();
+
         Matcher matcher = PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE.matcher(urlPattern);
-
-        StringBuffer stringBuffer = new StringBuffer();
-
         while (matcher.find()) {
             // By convention group 3 is the regex if provided by the user.
             // If it is not provided by the user the group 3 is null.
@@ -311,13 +310,13 @@ public class DefaultRouter implements Router {
                 namedVariablePartOfORouteReplacedWithRegex = VARIABLE_ROUTES_DEFAULT_REGEX;
             }
             // we replace the current namedVariablePartOfRoute group
-            matcher.appendReplacement(stringBuffer, namedVariablePartOfORouteReplacedWithRegex);
+            matcher.appendReplacement(buffer, namedVariablePartOfORouteReplacedWithRegex);
         }
 
         // .. and we append the tail to complete the stringBuffer
-        matcher.appendTail(stringBuffer);
+        matcher.appendTail(buffer);
 
-        return stringBuffer.toString();
+        return buffer.toString();
     }
 
     /**
@@ -333,13 +332,12 @@ public class DefaultRouter implements Router {
     private List<String> getParameterNames(String uriPattern) {
         List<String> list = new ArrayList<>();
 
-        Matcher m = PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE.matcher(uriPattern);
-
-        while (m.find()) {
+        Matcher matcher = PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE.matcher(uriPattern);
+        while (matcher.find()) {
             // group(1) is the name of the group. Must be always there...
             // "/assets/{file}" and "/assets/{file: [a-zA-Z][a-zA-Z_0-9]}"
             // will return file.
-            list.add(m.group(1));
+            list.add(matcher.group(1));
         }
 
         return list;

--- a/pippo-core/src/main/java/ro/pippo/core/route/FileResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/FileResourceHandler.java
@@ -40,7 +40,7 @@ public class FileResourceHandler extends StaticResourceHandler {
         URL url = null;
 
         try {
-            File file = new File(getResourceBasePath(), resourcePath);
+            File file = new File(getResourceBasePath(), resourcePath).getAbsoluteFile();
             if (file.exists() && file.isFile()) {
                 url = file.toURI().toURL();
             } else {

--- a/pippo-core/src/main/java/ro/pippo/core/route/FileResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/FileResourceHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.route;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Serves file resources.
+ *
+ * @author Decebal Suiu
+ */
+public class FileResourceHandler extends StaticResourceHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(FileResourceHandler.class);
+
+    public FileResourceHandler(String urlPath, String resourceBasePath) {
+        super(urlPath, resourceBasePath);
+    }
+
+    @Override
+    public URL getResourceUrl(String resourcePath) {
+        URL url = null;
+
+        try {
+            File file = new File(getResourceBasePath(), resourcePath);
+            if (file.exists() && file.isFile()) {
+                url = file.toURI().toURL();
+            } else {
+                log.error("File '{}' not found", file);
+            }
+        } catch (MalformedURLException e) {
+            log.error(e.getMessage(), e);
+        }
+
+        return url;
+    }
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/route/Router.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Router.java
@@ -59,6 +59,6 @@ public interface Router {
 
     public String uriFor(Class<? extends Controller> controllerClass, String methodName);
 
-    public String uriPatternFor(Class<? extends ClasspathResourceHandler> resourceHandlerClass);
+    public String uriPatternFor(Class<? extends StaticResourceHandler> resourceHandlerClass);
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/route/StaticResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/StaticResourceHandler.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.route;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ro.pippo.core.HttpConstants;
+import ro.pippo.core.PippoRuntimeException;
+import ro.pippo.core.Request;
+import ro.pippo.core.Response;
+import ro.pippo.core.util.HttpCacheToolkit;
+import ro.pippo.core.util.MimeTypes;
+import ro.pippo.core.util.StringUtils;
+
+import java.net.URL;
+import java.net.URLConnection;
+
+/**
+ * Serves static resources.
+ *
+ * @author James Moger
+ */
+public abstract class StaticResourceHandler implements RouteHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(StaticResourceHandler.class);
+
+    public static final String PATH_PARAMETER = "path";
+
+    private final String uriPattern;
+    private final String resourceBasePath;
+
+    private MimeTypes mimeTypes;
+
+    private HttpCacheToolkit httpCacheToolkit;
+
+    public StaticResourceHandler(String urlPath, String resourceBasePath) {
+        this.uriPattern = String.format("/%s/{%s: .*}", getNormalizedPath(urlPath), PATH_PARAMETER);
+        this.resourceBasePath = getNormalizedPath(resourceBasePath);
+    }
+
+    public String getResourceBasePath() {
+        return resourceBasePath;
+    }
+
+    public String getUriPattern() {
+        return uriPattern;
+    }
+
+    public void setMimeTypes(MimeTypes mimeTypes) {
+        this.mimeTypes = mimeTypes;
+    }
+
+    public void setHttpCacheToolkit(HttpCacheToolkit httpCacheToolkit) {
+        this.httpCacheToolkit = httpCacheToolkit;
+    }
+
+    @Override
+    public final void handle(Request request, Response response, RouteHandlerChain chain) {
+        String resourcePath = getResourcePath(request);
+        log.debug("Request resource '{}'", resourcePath);
+
+        URL url = getResourceUrl(resourcePath);
+        if (url == null) {
+            response.notFound().commit();
+        } else {
+            streamResource(url, request, response);
+        }
+
+        chain.next();
+    }
+
+    public abstract URL getResourceUrl(String resourcePath);
+
+    protected String getResourcePath(Request request) {
+        return getNormalizedPath(request.getParameter(PATH_PARAMETER).toString());
+    }
+
+    protected String getNormalizedPath(String path) {
+        if ('/' == path.charAt(0)) {
+            path = path.substring(1);
+        }
+        if ('/' == path.charAt(path.length() - 1)) {
+            path = path.substring(0, path.length() - 1);
+        }
+
+        return path;
+    }
+
+    /*
+    protected String getFilename(String path) {
+        return path.substring(path.lastIndexOf('/') + 1);
+    }
+    */
+
+    protected void streamResource(URL resourceUrl, Request request, Response response) {
+        try {
+            URLConnection urlConnection = resourceUrl.openConnection();
+            long lastModified = urlConnection.getLastModified();
+            httpCacheToolkit.addEtag(request, response, lastModified);
+
+            if (response.getStatus() == HttpConstants.StatusCode.NOT_MODIFIED) {
+                // Do not stream anything out. Simply return 304
+                log.debug("Unmodified resource '{}'", resourceUrl);
+                response.commit();
+            } else {
+                String filename = resourceUrl.getFile();
+
+                // Try to set the mimetype:
+                String mimeType = mimeTypes.getContentType(request, response, filename);
+
+                if (!StringUtils.isNullOrEmpty(mimeType)) {
+                    // stream the resource
+                    log.debug("Streaming as resource '{}'", resourceUrl);
+                    response.contentType(mimeType);
+                    response.resource(urlConnection.getInputStream());
+                } else {
+                    // stream the file
+                    log.debug("Streaming as file '{}'", resourceUrl);
+                    response.file(filename, urlConnection.getInputStream());
+                }
+            }
+        } catch (Exception e) {
+            throw new PippoRuntimeException("Failed to stream resource " + resourceUrl, e);
+        }
+    }
+
+}

--- a/pippo-demo/pippo-demo-basic/src/main/java/ro/pippo/demo/basic/BasicApplication.java
+++ b/pippo-demo/pippo-demo-basic/src/main/java/ro/pippo/demo/basic/BasicApplication.java
@@ -19,6 +19,7 @@ import ro.pippo.core.Application;
 import ro.pippo.core.HttpConstants;
 import ro.pippo.core.Request;
 import ro.pippo.core.Response;
+import ro.pippo.core.route.FileResourceHandler;
 import ro.pippo.core.route.RouteHandler;
 import ro.pippo.core.route.RouteHandlerChain;
 import ro.pippo.demo.common.Contact;
@@ -155,6 +156,9 @@ public class BasicApplication extends Application {
             }
 
         });
+
+         // send files from a local folder (try a request like 'src/main/java/ro/pippo/demo/basic/BasicApplication.java')
+        GET(new FileResourceHandler("/src", "src"));
     }
 
 }


### PR DESCRIPTION
Now are two implementations available `ClasspathResourceHandler` (serves classpath resources) and `FileResourceHandler` (serves file resources)
I improved pippo-demo-basic with a new route:
```java
// send files from a local folder (try a request like 'src/main/java/ro/pippo/demo/basic/BasicApplication.java')
GET(new FileResourceHandler("/src", "src"));
```
What you think?