### PR TITLE
Improvements & fixes to the FileResourceHandler

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/route/ClasspathResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/ClasspathResourceHandler.java
@@ -24,13 +24,20 @@ import java.net.URL;
  */
 public class ClasspathResourceHandler extends StaticResourceHandler {
 
+    private final String resourceBasePath;
+
     public ClasspathResourceHandler(String urlPath, String resourceBasePath) {
-        super(urlPath, resourceBasePath);
+        super(urlPath);
+        this.resourceBasePath = getNormalizedPath(resourceBasePath);
     }
 
     @Override
     public URL getResourceUrl(String resourcePath) {
         return this.getClass().getClassLoader().getResource(getResourceBasePath() + "/" + resourcePath);
+    }
+
+    public String getResourceBasePath() {
+        return resourceBasePath;
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/route/FileResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/FileResourceHandler.java
@@ -31,8 +31,15 @@ public class FileResourceHandler extends StaticResourceHandler {
 
     private static final Logger log = LoggerFactory.getLogger(FileResourceHandler.class);
 
-    public FileResourceHandler(String urlPath, String resourceBasePath) {
-        super(urlPath, resourceBasePath);
+    final File directory;
+
+    public FileResourceHandler(String urlPath, File directory) {
+        super(urlPath);
+        this.directory = directory.getAbsoluteFile();
+    }
+
+    public FileResourceHandler(String urlPath, String directory) {
+        this(urlPath, new File(directory));
     }
 
     @Override
@@ -40,7 +47,7 @@ public class FileResourceHandler extends StaticResourceHandler {
         URL url = null;
 
         try {
-            File file = new File(getResourceBasePath(), resourcePath).getAbsoluteFile();
+            File file = new File(directory, resourcePath).getAbsoluteFile();
             if (file.exists() && file.isFile()) {
                 url = file.toURI().toURL();
             } else {

--- a/pippo-core/src/main/java/ro/pippo/core/route/StaticResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/StaticResourceHandler.java
@@ -40,19 +40,13 @@ public abstract class StaticResourceHandler implements RouteHandler {
     public static final String PATH_PARAMETER = "path";
 
     private final String uriPattern;
-    private final String resourceBasePath;
 
     private MimeTypes mimeTypes;
 
     private HttpCacheToolkit httpCacheToolkit;
 
-    public StaticResourceHandler(String urlPath, String resourceBasePath) {
+    public StaticResourceHandler(String urlPath) {
         this.uriPattern = String.format("/%s/{%s: .*}", getNormalizedPath(urlPath), PATH_PARAMETER);
-        this.resourceBasePath = getNormalizedPath(resourceBasePath);
-    }
-
-    public String getResourceBasePath() {
-        return resourceBasePath;
     }
 
     public String getUriPattern() {
@@ -98,12 +92,6 @@ public abstract class StaticResourceHandler implements RouteHandler {
 
         return path;
     }
-
-    /*
-    protected String getFilename(String path) {
-        return path.substring(path.lastIndexOf('/') + 1);
-    }
-    */
 
     protected void streamResource(URL resourceUrl, Request request, Response response) {
         try {


### PR DESCRIPTION
The file resource handler could not serve anything outside `user.dir` and it should accept a File argument.