### PR TITLE
SessionFactory must create sessions

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/DefaultSessionFactory.java
+++ b/pippo-core/src/main/java/ro/pippo/core/DefaultSessionFactory.java
@@ -23,8 +23,8 @@ import javax.servlet.http.HttpSession;
 public class DefaultSessionFactory implements SessionFactory {
 
     @Override
-    public Session createSession(Request request, boolean create) {
-        HttpSession httpSession = request.getHttpServletRequest().getSession(create);
+    public Session createSession(Request request) {
+        HttpSession httpSession = request.getHttpServletRequest().getSession(true);
 
         return new DefaultSession(httpSession);
     }

--- a/pippo-core/src/main/java/ro/pippo/core/Request.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Request.java
@@ -322,8 +322,8 @@ public class Request {
     }
 
     public Session getSession(boolean create) {
-        if (session == null) {
-            session = sessionFactory.createSession(this, create);
+        if (session == null && create) {
+            session = sessionFactory.createSession(this);
         }
 
         return session;

--- a/pippo-core/src/main/java/ro/pippo/core/SessionFactory.java
+++ b/pippo-core/src/main/java/ro/pippo/core/SessionFactory.java
@@ -21,13 +21,11 @@ package ro.pippo.core;
 public interface SessionFactory {
 
     /**
-     * Returns the current <code>Session</code> associated with a request or, if there is no
-     * current session and <code>create</code> is true, returns a new session.
+     * Creates a new session.
      *
      * @param request
-     * @param create
-     * @return
+     * @return a session
      */
-    public Session createSession(Request request, boolean create);
+    public Session createSession(Request request);
 
 }


### PR DESCRIPTION
SessionFactory must create a complete session.  If "create" is passed as a parameter
then DefaultSessions can be created with a null httpSession which is wrong.

The correct behavior is for the Request to control creation of the Session.

Refs #87.