### PR TITLE
Fix DefaultSessionFactory

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/DefaultSessionFactory.java
+++ b/pippo-core/src/main/java/ro/pippo/core/DefaultSessionFactory.java
@@ -25,6 +25,10 @@ public class DefaultSessionFactory implements SessionFactory {
     @Override
     public Session createSession(Request request, boolean create) {
         HttpSession httpSession = request.getHttpServletRequest().getSession(create);
+        if (httpSession == null) {
+            // without a servlet session we can not have a DefaultSession
+            return null;
+        }
 
         return new DefaultSession(httpSession);
     }


### PR DESCRIPTION
If a servlet session is not created we can not have a DefaultSession.