### PR TITLE
Add support for naming routes to bring meaningful context to logs

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/Application.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Application.java
@@ -188,62 +188,62 @@ public class Application {
         getRouter().setContextPath(contextPath);
     }
 
-    public void GET(StaticResourceHandler resourceHandler) {
+    public Route GET(StaticResourceHandler resourceHandler) {
         if (getRouter().uriPatternFor(resourceHandler.getClass()) != null) {
             throw new PippoRuntimeException("You may only register one route for {}",
                     resourceHandler.getClass().getSimpleName());
         }
         resourceHandler.setMimeTypes(mimeTypes);
         resourceHandler.setHttpCacheToolkit(httpCacheToolkit);
-        addRoute(resourceHandler.getUriPattern(), HttpConstants.Method.GET, resourceHandler);
+        return addRoute(resourceHandler.getUriPattern(), HttpConstants.Method.GET, resourceHandler);
     }
 
-    public void GET(String uriPattern, RouteHandler routeHandler) {
-        addRoute(uriPattern, HttpConstants.Method.GET, routeHandler);
+    public Route GET(String uriPattern, RouteHandler routeHandler) {
+        return addRoute(uriPattern, HttpConstants.Method.GET, routeHandler);
     }
 
-    public void GET(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        addRoute(uriPattern, HttpConstants.Method.GET, controllerClass, methodName);
+    public Route GET(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
+        return addRoute(uriPattern, HttpConstants.Method.GET, controllerClass, methodName);
     }
 
-    public void POST(String uriPattern, RouteHandler routeHandler) {
-        addRoute(uriPattern, HttpConstants.Method.POST, routeHandler);
+    public Route POST(String uriPattern, RouteHandler routeHandler) {
+        return addRoute(uriPattern, HttpConstants.Method.POST, routeHandler);
     }
 
-    public void POST(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        addRoute(uriPattern, HttpConstants.Method.POST, controllerClass, methodName);
+    public Route POST(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
+        return addRoute(uriPattern, HttpConstants.Method.POST, controllerClass, methodName);
     }
 
-    public void DELETE(String uriPattern, RouteHandler routeHandler) {
-        addRoute(uriPattern, HttpConstants.Method.DELETE, routeHandler);
+    public Route DELETE(String uriPattern, RouteHandler routeHandler) {
+        return addRoute(uriPattern, HttpConstants.Method.DELETE, routeHandler);
     }
 
-    public void DELETE(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        addRoute(uriPattern, HttpConstants.Method.DELETE, controllerClass, methodName);
+    public Route DELETE(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
+        return addRoute(uriPattern, HttpConstants.Method.DELETE, controllerClass, methodName);
     }
 
-    public void HEAD(String uriPattern, RouteHandler routeHandler) {
-        addRoute(uriPattern, HttpConstants.Method.HEAD, routeHandler);
+    public Route HEAD(String uriPattern, RouteHandler routeHandler) {
+        return addRoute(uriPattern, HttpConstants.Method.HEAD, routeHandler);
     }
 
-    public void HEAD(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        addRoute(uriPattern, HttpConstants.Method.HEAD, controllerClass, methodName);
+    public Route HEAD(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
+        return addRoute(uriPattern, HttpConstants.Method.HEAD, controllerClass, methodName);
     }
 
-    public void PUT(String uriPattern, RouteHandler routeHandler) {
-        addRoute(uriPattern, HttpConstants.Method.PUT, routeHandler);
+    public Route PUT(String uriPattern, RouteHandler routeHandler) {
+        return addRoute(uriPattern, HttpConstants.Method.PUT, routeHandler);
     }
 
-    public void PUT(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        addRoute(uriPattern, HttpConstants.Method.PUT, controllerClass, methodName);
+    public Route PUT(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
+        return addRoute(uriPattern, HttpConstants.Method.PUT, controllerClass, methodName);
     }
 
-    public void PATCH(String uriPattern, RouteHandler routeHandler) {
-        addRoute(uriPattern, HttpConstants.Method.PATCH, routeHandler);
+    public Route PATCH(String uriPattern, RouteHandler routeHandler) {
+        return addRoute(uriPattern, HttpConstants.Method.PATCH, routeHandler);
     }
 
-    public void PATCH(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        addRoute(uriPattern, HttpConstants.Method.PATCH, controllerClass, methodName);
+    public Route PATCH(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
+        return addRoute(uriPattern, HttpConstants.Method.PATCH, controllerClass, methodName);
     }
 
     public Route ALL(String uriPattern, RouteHandler routeHandler) {

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouteContext.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouteContext.java
@@ -22,6 +22,7 @@ import ro.pippo.core.ParameterValue;
 import ro.pippo.core.Request;
 import ro.pippo.core.Response;
 import ro.pippo.core.Session;
+import ro.pippo.core.util.StringUtils;
 
 import java.io.File;
 import java.util.Iterator;
@@ -233,19 +234,18 @@ public class DefaultRouteContext implements RouteContext {
             // retrieves the next route
             RouteMatch routeMatch = iterator.next();
             Route route = routeMatch.getRoute();
-            log.debug("Found {}", route);
+            log.trace("Found {}", route);
 
             // set the new path parameters in request
             Map<String, String> pathParameters = routeMatch.getPathParameters();
             if (pathParameters != null) {
                 request.setPathParameters(pathParameters);
-                log.debug("Added path parameters to request");
+                log.trace("Added path parameters to request");
             }
 
             // remove route from chain
             iterator.remove();
 
-            log.debug("Call handler for {}", route);
             handleRoute(route);
         }
     }
@@ -256,15 +256,21 @@ public class DefaultRouteContext implements RouteContext {
     @Override
     public void runFinallyRoutes() {
         while (iterator.hasNext()) {
-            RouteMatch routeMatch = iterator.next();
-            if (routeMatch.getRoute().isRunAsFinally()) {
+            Route route = iterator.next().getRoute();
+            if (route.isRunAsFinally()) {
                 try {
-                    handleRoute(routeMatch.getRoute());
+                    handleRoute(route);
                 } catch (Exception e) {
                     log.error("Unexpected error in Finally Route", e);
                 }
             } else if (log.isDebugEnabled()) {
-                log.debug("chain.next() not called, skipping {}", routeMatch);
+                if (StringUtils.isNullOrEmpty(route.getName())) {
+                    log.debug("context.next() not called, skipping handler for {} '{}'", route.getRequestMethod(),
+                        route.getUriPattern());
+                } else {
+                    log.debug("context.next() not called, skipping '{}' for {} '{}'", route.getName(),
+                        route.getRequestMethod(), route.getUriPattern());
+                }
             }
         }
     }
@@ -320,6 +326,11 @@ public class DefaultRouteContext implements RouteContext {
 
 
     protected void handleRoute(Route route) {
+        if (StringUtils.isNullOrEmpty(route.getName())) {
+            log.debug("Executing handler for {} '{}'", route.getRequestMethod(), route.getUriPattern());
+        } else {
+            log.debug("Executing '{}' for {} '{}'", route.getName(), route.getRequestMethod(), route.getUriPattern());
+        }
         route.getRouteHandler().handle(this);
     }
 }

--- a/pippo-core/src/main/java/ro/pippo/core/route/Route.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Route.java
@@ -24,6 +24,7 @@ public class Route {
     private String requestMethod;
     private RouteHandler routeHandler;
     private boolean runAsFinally;
+    private String name;
 
     public Route(String uriPattern, String requestMethod, RouteHandler routeHandler) {
         this.uriPattern = uriPattern;
@@ -53,6 +54,20 @@ public class Route {
      */
     public void runAsFinally() {
         runAsFinally = true;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Route named(String name) {
+        this.name = name;
+
+        return this;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     @Override

--- a/pippo-demo/pippo-demo-basic/src/main/java/ro/pippo/demo/basic/BasicApplication.java
+++ b/pippo-demo/pippo-demo-basic/src/main/java/ro/pippo/demo/basic/BasicApplication.java
@@ -47,7 +47,7 @@ public class BasicApplication extends Application {
                 routeContext.send("Hello World");
             }
 
-        });
+        }).named("Hello World handler");
 
         // send a file as response
         GET("/file", new RouteHandler() {
@@ -180,7 +180,7 @@ public class BasicApplication extends Application {
                 log.info(">>> Cleanup here");
             }
 
-        }).runAsFinally();
+        }).named("cleanup filter").runAsFinally();
     }
 
 }


### PR DESCRIPTION
Once your app gets large enough, logging by method and uri pattern is insufficient.

This PR adds the builder pattern to route registration with the first supported value as `Route` *name*.