### PR TITLE
Allow registration of custom ExceptionHandlers

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/ErrorHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/ErrorHandler.java
@@ -19,12 +19,21 @@ package ro.pippo.core;
 import ro.pippo.core.route.RouteContext;
 
 /**
+ * ErrorHandler is the core ExceptionHandler.
+ * <p>
+ * ErrorHandler can register custom ExceptionHandlers and will handle an exception
+ * with a matching ExceptionHandler, if found.  Otherwise ErrorHandler will fallback
+ * to itself to handle the exception.
+ * </p>
+ *
  * @author Decebal Suiu
  */
-public interface ErrorHandler {
+public interface ErrorHandler extends ExceptionHandler {
+
+    public void setExceptionHandler(Class<? extends Exception> exceptionClass, ExceptionHandler exceptionHandler);
+
+    public ExceptionHandler getExceptionHandler(Exception exception);
 
     public void handle(int statusCode, RouteContext routeContext);
-
-    public void handle(Exception exception, RouteContext routeContext);
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/ExceptionHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/ExceptionHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ro.pippo.core;
+
+import ro.pippo.core.route.RouteContext;
+
+/**
+ * @author James Moger
+ */
+public interface ExceptionHandler {
+
+    /**
+     * Handles an exception.
+     *
+     * @param exception
+     * @param routeContext
+     */
+    void handle(Exception exception, RouteContext routeContext);
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
@@ -196,7 +196,6 @@ public class PippoFilter implements Filter {
                 }
             }
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
             errorHandler.handle(e, routeContext);
         } finally {
             routeContext.runFinallyRoutes();


### PR DESCRIPTION
This is a light-weight alternative to implementing a full `ErrorHandler` or subclassing `DefaultErrorHandler`.

The `ErrorHandler` is also an `ExceptionHandler` so if no registered `ExceptionHandler` is found for the exception, then the `ErrorHandler` implementation is used.  But the `ErrorHandler` is more than an `ExceptionHandler` because it is a registry of `ExceptionHandler` instances and it can generate status-code based results.

This is an important piece when integrating custom or library exceptions into a Pippo application.