### PR TITLE
Allow specifying a non-root Pippo filter or servlet path

### DIFF
--- a/pippo-controller/src/main/java/ro/pippo/controller/DefaultControllerRouter.java
+++ b/pippo-controller/src/main/java/ro/pippo/controller/DefaultControllerRouter.java
@@ -44,7 +44,7 @@ public class DefaultControllerRouter extends DefaultRouter implements Controller
     public String uriFor(Class<? extends Controller> controllerClass, String methodName, Map<String, Object> parameters) {
         Route route = getRoute(controllerClass, methodName);
 
-        return (route != null) ? prefixContextPath(uriFor(route.getUriPattern(), parameters)) : null;
+        return (route != null) ? prefixApplicationPath(uriFor(route.getUriPattern(), parameters)) : null;
     }
 
     private Route getRoute(Class<? extends Controller> controllerClass, String methodName) {

--- a/pippo-core/src/main/java/ro/pippo/core/Application.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Application.java
@@ -216,10 +216,6 @@ public class Application {
         this.router = router;
     }
 
-    void setContextPath(String contextPath) {
-        getRouter().setContextPath(contextPath);
-    }
-
     public Route GET(StaticResourceHandler resourceHandler) {
         if (getRouter().uriPatternFor(resourceHandler.getClass()) != null) {
             throw new PippoRuntimeException("You may only register one route for {}",

--- a/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
@@ -233,30 +233,4 @@ public class PippoFilter implements Filter {
         }
     }
 
-    /**
-     * Returns a relative path to the filter path and context root.
-     */
-    private String getRelativePath(String contextPath, String path) {
-        String relativePath = path.substring(contextPath.length());
-
-        if (relativePath.length() > 0) {
-            relativePath = relativePath.substring(1);
-        }
-
-        if (!relativePath.startsWith(filterPath))  {
-            if (filterPath.equals(relativePath + "/"))  {
-                relativePath += "/";
-            }
-        }
-        if (relativePath.startsWith(filterPath)) {
-            relativePath = relativePath.substring(filterPath.length());
-        }
-
-        if (!relativePath.startsWith("/")) {
-            relativePath = "/" + relativePath;
-        }
-
-        return relativePath;
-    }
-
 }

--- a/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
@@ -82,7 +82,7 @@ public class PippoFilter implements Filter {
             if (filterPath == null) {
                 initFilterPath(filterConfig);
             }
-            String applicationPath = contextPath + filterPath;
+            String applicationPath = contextPath + "/" + filterPath;
             application.getRouter().setApplicationPath(applicationPath);
 
             if (!contextPath.equals(applicationPath)) {
@@ -119,13 +119,13 @@ public class PippoFilter implements Filter {
         // create a URI to automatically decode the path
         URI uri = URI.create(httpServletRequest.getRequestURL().toString());
         String requestUri = uri.getPath();
-        String relativePath = request.getApplicationRequestPath();
+        String requestPath = request.getPath();
 
-        log.trace("The relative path for '{}' is '{}'", requestUri, relativePath);
+        log.trace("The relative path for '{}' is '{}'", requestUri, requestPath);
 
         // check for ignore path
-        if (shouldIgnorePath(relativePath)) {
-            log.debug("Ignoring request '{}'", relativePath);
+        if (shouldIgnorePath(requestPath)) {
+            log.debug("Ignoring request '{}'", requestPath);
             if (chain != null) {
                 chain.doFilter(servletRequest, servletResponse);
             }
@@ -133,7 +133,7 @@ public class PippoFilter implements Filter {
             return;
         }
 
-        log.debug("Request {} '{}'", httpServletRequest.getMethod(), relativePath);
+        log.debug("Request {} '{}'", httpServletRequest.getMethod(), requestPath);
 
         // dispatch route(s)
         routeDispatcher.dispatch(request, response);

--- a/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
@@ -82,7 +82,7 @@ public class PippoFilter implements Filter {
             if (filterPath == null) {
                 initFilterPath(filterConfig);
             }
-            String applicationPath = getApplicationPath(contextPath, filterPath);
+            String applicationPath = StringUtils.addEnd(contextPath, "/") + StringUtils.removeStart(filterPath, "/");
             application.getRouter().setApplicationPath(applicationPath);
 
             if (!contextPath.equals(applicationPath)) {
@@ -231,20 +231,6 @@ public class PippoFilter implements Filter {
             log.error("Cannot create application with className '{}'", applicationClassName, e);
             throw new ServletException(e);
         }
-    }
-
-    private String getApplicationPath(String contextPath, String filterPath) {
-        String applicationPath = contextPath;
-
-        System.out.println("filterPath = " + filterPath);
-        if (!filterPath.isEmpty()) {
-            if (!contextPath.equals("/")) {
-                applicationPath += "/";;
-            }
-            applicationPath += filterPath;
-        }
-
-        return applicationPath;
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
@@ -82,7 +82,7 @@ public class PippoFilter implements Filter {
             if (filterPath == null) {
                 initFilterPath(filterConfig);
             }
-            String applicationPath = contextPath + "/" + filterPath;
+            String applicationPath = getApplicationPath(contextPath, filterPath);
             application.getRouter().setApplicationPath(applicationPath);
 
             if (!contextPath.equals(applicationPath)) {
@@ -231,6 +231,20 @@ public class PippoFilter implements Filter {
             log.error("Cannot create application with className '{}'", applicationClassName, e);
             throw new ServletException(e);
         }
+    }
+
+    private String getApplicationPath(String contextPath, String filterPath) {
+        String applicationPath = contextPath;
+
+        System.out.println("filterPath = " + filterPath);
+        if (!filterPath.isEmpty()) {
+            if (!contextPath.equals("/")) {
+                applicationPath += "/";;
+            }
+            applicationPath += filterPath;
+        }
+
+        return applicationPath;
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/PippoServlet.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoServlet.java
@@ -109,11 +109,11 @@ public class PippoServlet extends HttpServlet {
         // create a URI to automatically decode the path
         URI uri = URI.create(httpServletRequest.getRequestURL().toString());
         String requestUri = uri.getPath();
-        String relativePath = request.getApplicationRequestPath();
+        String requestPath = request.getPath();
 
-        log.trace("The relative path for '{}' is '{}'", requestUri, relativePath);
+        log.trace("The relative path for '{}' is '{}'", requestUri, requestPath);
 
-        log.debug("Request {} '{}'", httpServletRequest.getMethod(), relativePath);
+        log.debug("Request {} '{}'", httpServletRequest.getMethod(), requestPath);
 
         // dispatch route(s)
         routeDispatcher.dispatch(request, response);

--- a/pippo-core/src/main/java/ro/pippo/core/Response.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Response.java
@@ -50,6 +50,7 @@ public final class Response {
     private Map<String, String> headers;
     private Map<String, Cookie> cookies;
     private String contextPath;
+    private String applicationPath;
     private ResponseFinalizeListenerList finalizeListeners;
 
     private int status;
@@ -60,6 +61,7 @@ public final class Response {
         this.templateEngine = application.getTemplateEngine();
         this.httpServletResponse.setCharacterEncoding(StandardCharsets.UTF_8.toString());
         this.contextPath = application.getRouter().getContextPath();
+        this.applicationPath = StringUtils.removeEnd(application.getRouter().getApplicationPath(), "/");
 
         this.status = 0;
     }
@@ -329,6 +331,7 @@ public final class Response {
      * <li>an absolute url
      * </ul>
      * If you want a context-relative redirect, use the {@link redirectToContextPath}
+     * If you want an application-relative redirect, use the {@link redirectToApplicationPath}
      * method.
      * <p>This method commits the response.</p>
      *
@@ -360,6 +363,23 @@ public final class Response {
             redirect(path);
         } else {
             redirect(contextPath + StringUtils.addStart(path, "/"));
+        }
+    }
+
+    /**
+     * Redirects the browser to a path relative to the Pippo application root. For
+     * example, redirectToApplicationPath("/contacts") might redirect the browser to
+     * http://localhost/myContext/myApp/contacts
+     * <p>This method commits the response.</p>
+     *
+     * @param path
+     */
+    public void redirectToApplicationPath(String path) {
+        if ("".equals(applicationPath)) {
+            // application path is the root
+            redirect(path);
+        } else {
+            redirect(applicationPath + StringUtils.addStart(path, "/"));
         }
     }
 

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouteContext.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouteContext.java
@@ -185,7 +185,7 @@ public class DefaultRouteContext implements RouteContext {
 
     @Override
     public String getRequestUri() {
-        return request.getContextUri();
+        return request.getApplicationUri();
     }
 
     @Override
@@ -225,7 +225,7 @@ public class DefaultRouteContext implements RouteContext {
 
     @Override
     public void redirect(String path) {
-        response.redirectToContextPath(path);
+        response.redirectToApplicationPath(path);
     }
 
     @Override

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -62,7 +62,7 @@ public class DefaultRouter implements Router {
     private Set<String> ignorePaths;
     private Map<String, List<Route>> cache; // key = request method
     private String contextPath;
-    private String filterPath;
+    private String applicationPath;
 
     public DefaultRouter() {
         routes = new ArrayList<>();
@@ -70,6 +70,7 @@ public class DefaultRouter implements Router {
         cache = new HashMap<>();
         bindingsCache = new HashMap<>();
         contextPath = "";
+        applicationPath = "";
     }
 
     @Override
@@ -87,13 +88,13 @@ public class DefaultRouter implements Router {
     }
 
     /**
-     * Prefix the given path with the context path.
+     * Prefix the given path with the application path.
      *
      * @param path
      * @return an absolute path
      */
-    protected String prefixContextPath(String path) {
-        return contextPath + StringUtils.addStart(path, "/");
+    protected String prefixApplicationPath(String path) {
+        return applicationPath + StringUtils.addStart(path, "/");
     }
 
     @Override
@@ -190,14 +191,14 @@ public class DefaultRouter implements Router {
 
     @Override
     public String uriFor(String relativeUri) {
-        return prefixContextPath(relativeUri);
+        return prefixApplicationPath(relativeUri);
     }
 
     @Override
     public String uriFor(String uriPattern, Map<String, Object> parameters) {
         PatternBinding binding = getBinding(uriPattern);
 
-        return (binding != null) ? prefixContextPath(uriFor(binding, parameters)) : null;
+        return (binding != null) ? prefixApplicationPath(uriFor(binding, parameters)) : null;
     }
 
     @Override
@@ -208,13 +209,17 @@ public class DefaultRouter implements Router {
     }
 
     @Override
-    public String getFilterPath() {
-        return filterPath;
+    public String getApplicationPath() {
+        return applicationPath;
     }
 
     @Override
-    public void setFilterPath(String filterPath) {
-        this.filterPath = filterPath;
+    public void setApplicationPath(String applicationPath) {
+        if (StringUtils.isNullOrEmpty(applicationPath) || "/".equals(applicationPath.trim())) {
+            this.applicationPath = "";
+        } else {
+            this.applicationPath = StringUtils.removeEnd(StringUtils.addStart(applicationPath, "/"), "/");
+        }
     }
 
     private Route getRoute(Class<? extends StaticResourceHandler> resourceHandlerClass) {

--- a/pippo-core/src/main/java/ro/pippo/core/route/RouteDispatcher.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/RouteDispatcher.java
@@ -117,7 +117,7 @@ public class RouteDispatcher {
      * @param response
      */
     protected void onRouteDispatch(Request request, Response response) {
-        final String requestPath = request.getApplicationRequestPath();
+        final String requestPath = request.getPath();
         final String requestMethod = request.getMethod();
 
         if (shouldIgnorePath(requestPath)) {

--- a/pippo-core/src/main/java/ro/pippo/core/route/RouteDispatcher.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/RouteDispatcher.java
@@ -117,7 +117,7 @@ public class RouteDispatcher {
      * @param response
      */
     protected void onRouteDispatch(Request request, Response response) {
-        final String requestPath = request.getRelativePath();
+        final String requestPath = request.getApplicationRequestPath();
         final String requestMethod = request.getMethod();
 
         if (shouldIgnorePath(requestPath)) {

--- a/pippo-core/src/main/java/ro/pippo/core/route/Router.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Router.java
@@ -67,10 +67,10 @@ public interface Router {
     public String uriPatternFor(Class<? extends StaticResourceHandler> resourceHandlerClass);
 
     /**
-     * Returns the path to which PippoFilter is mapped.
+     * Returns the base path for the Pippo application.
      */
-    public String getFilterPath();
+    public String getApplicationPath();
 
-    public void setFilterPath(String filterPath);
+    public void setApplicationPath(String pippoPath);
 
 }

--- a/pippo-demo/pippo-demo-basic/src/main/java/ro/pippo/demo/basic/BasicApplication.java
+++ b/pippo-demo/pippo-demo-basic/src/main/java/ro/pippo/demo/basic/BasicApplication.java
@@ -20,9 +20,12 @@ import org.slf4j.LoggerFactory;
 import ro.pippo.core.Application;
 import ro.pippo.core.ExceptionHandler;
 import ro.pippo.core.HttpConstants;
+import ro.pippo.core.Request;
+import ro.pippo.core.Response;
 import ro.pippo.core.route.FileResourceHandler;
 import ro.pippo.core.route.RouteContext;
 import ro.pippo.core.route.RouteHandler;
+import ro.pippo.core.route.RoutePreDispatchListener;
 import ro.pippo.demo.common.Contact;
 
 import java.io.File;
@@ -181,6 +184,17 @@ public class BasicApplication extends Application {
 
         });
 
+        // use a finally filter (invoked even when exceptions were raised in previous routes)
+        // test with route "/" and "/exception"
+        ALL("/.*", new RouteHandler() {
+
+            @Override
+            public void handle(RouteContext routeContext) {
+                log.info(">>> Cleanup here");
+            }
+
+        }).named("cleanup filter").runAsFinally();
+
         // register a custom ExceptionHandler
         getErrorHandler().setExceptionHandler(ForbiddenException.class, new ExceptionHandler() {
 
@@ -193,16 +207,23 @@ public class BasicApplication extends Application {
 
         });
 
-        // use a finally filter (invoked even when exceptions were raised in previous routes)
-        // test with route "/" and "/exception"
-        ALL("/.*", new RouteHandler() {
+        // register a request logger
+        getRoutePreDispatchListeners().add(new RoutePreDispatchListener() {
 
             @Override
-            public void handle(RouteContext routeContext) {
-                log.info(">>> Cleanup here");
+            public void onPreDispatch(Request request, Response response) {
+                System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+                System.out.println("requestPath = " + request.getPath());
+                System.out.println("requestUri = " + request.getUri());
+                System.out.println("requestUrl = " + request.getUrl());
+                System.out.println("contextPath = " + request.getContextPath());
+                System.out.println("applicationPath = " + request.getApplicationPath());
+                System.out.println("applicationUri = " + request.getApplicationUri());
+                System.out.println("applicationUriWithQuery = " + request.getApplicationUriWithQuery());
+                System.out.println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
             }
 
-        }).named("cleanup filter").runAsFinally();
+        });
     }
 
     public static class ForbiddenException extends RuntimeException {

--- a/pippo-demo/pippo-demo-basic/src/main/webapp/WEB-INF/web.xml
+++ b/pippo-demo/pippo-demo-basic/src/main/webapp/WEB-INF/web.xml
@@ -20,6 +20,9 @@
 
     <filter-mapping>
         <filter-name>pippo</filter-name>
+        <!--
+        <url-pattern>/web/*</url-pattern>
+        -->
         <url-pattern>/*</url-pattern>
     </filter-mapping>
 

--- a/pippo-demo/pippo-demo-crud/src/main/java/ro/pippo/demo/crud/CrudApplication.java
+++ b/pippo-demo/pippo-demo-crud/src/main/java/ro/pippo/demo/crud/CrudApplication.java
@@ -64,7 +64,7 @@ public class CrudApplication extends Application {
             @Override
             public void handle(RouteContext routeContext) {
                 if (routeContext.getSession("username") == null) {
-                    routeContext.setSession("originalDestination", routeContext.getRequest().getContextUriWithQuery());
+                    routeContext.setSession("originalDestination", routeContext.getRequest().getApplicationUriWithQuery());
                     routeContext.redirect("/login");
                 } else {
                     routeContext.next();

--- a/pippo-demo/pippo-demo-crud/src/main/java/ro/pippo/demo/crud/CrudDemo.java
+++ b/pippo-demo/pippo-demo-crud/src/main/java/ro/pippo/demo/crud/CrudDemo.java
@@ -24,6 +24,7 @@ public class CrudDemo {
 
     public static void main(String[] args) {
         Pippo pippo = new Pippo(new CrudApplication());
+//        pippo.getServer().setPippoFilterPath("/web/*");
         pippo.start();
     }
 

--- a/pippo-demo/pippo-demo-crud/src/main/resources/templates/contacts.ftl
+++ b/pippo-demo/pippo-demo-crud/src/main/resources/templates/contacts.ftl
@@ -5,7 +5,7 @@
     </div>
 
     <div class="buttons pull-right">
-        <a id="addContactButton" type="button" class="btn btn-primary" href="${contextPath}/contact/0?action=new"><i class="fa fa-plus"></i> Add Contact</a>
+        <a id="addContactButton" type="button" class="btn btn-primary" href="${appPath}/contact/0?action=new"><i class="fa fa-plus"></i> Add Contact</a>
     </div>
 
     <table class="table table-striped table-bordered table-hover">
@@ -26,8 +26,8 @@
                 <td>${contact.address}</td>
                 <td style="text-align: right;">
                     <div class="btn-group btn-group-xs">
-                        <a class="btn btn-default" href="${contextPath}/contact/${contact.id}?action=edit"><i class="fa fa-pencil"></i> Edit</a>
-                        <a class="btn btn-default" href="${contextPath}/contact/${contact.id}?action=delete"><i class="fa fa-trash"></i> Delete</a>
+                        <a class="btn btn-default" href="${appPath}/contact/${contact.id}?action=edit"><i class="fa fa-pencil"></i> Edit</a>
+                        <a class="btn btn-default" href="${appPath}/contact/${contact.id}?action=delete"><i class="fa fa-trash"></i> Delete</a>
                     </div>
                 </td>
             </tr>

--- a/pippo-demo/pippo-demo-crud/src/main/resources/templates/login.ftl
+++ b/pippo-demo/pippo-demo-crud/src/main/resources/templates/login.ftl
@@ -17,7 +17,7 @@
                     <h3 class="panel-title">Please sign in</h3>
                 </div>
                 <div class="panel-body">
-                    <form accept-charset="UTF-8" role="form" method="post" action="${contextPath}/login">
+                    <form accept-charset="UTF-8" role="form" method="post" action="${appPath}/login">
                         <fieldset>
                             <div class="form-group">
                                 <input class="form-control" placeholder="Username" name="username">

--- a/pippo-demo/pippo-demo-crudng/src/main/java/ro/pippo/demo/crudng/CrudNgApplication.java
+++ b/pippo-demo/pippo-demo-crudng/src/main/java/ro/pippo/demo/crudng/CrudNgApplication.java
@@ -69,7 +69,7 @@ public class CrudNgApplication extends ControllerApplication {
             @Override
             public void handle(RouteContext routeContext) {
                 if (routeContext.getSession("username") == null) {
-                    routeContext.setSession("originalDestination", routeContext.getRequest().getContextUriWithQuery());
+                    routeContext.setSession("originalDestination", routeContext.getRequest().getApplicationUriWithQuery());
                     routeContext.redirect("/login");
                 } else {
                     routeContext.next();

--- a/pippo-demo/pippo-demo-crudng/src/main/resources/templates/login.ftl
+++ b/pippo-demo/pippo-demo-crudng/src/main/resources/templates/login.ftl
@@ -17,7 +17,7 @@
                     <h3 class="panel-title">Please sign in</h3>
                 </div>
                 <div class="panel-body">
-                    <form accept-charset="UTF-8" role="form" method="post" action="${contextPath}/login">
+                    <form accept-charset="UTF-8" role="form" method="post" action="${appPath}/login">
                         <fieldset>
                             <div class="form-group">
                                 <input class="form-control" placeholder="Username" name="username">

--- a/pippo-demo/pippo-demo-template/src/main/resources/templates/freemarker/hello.ftl
+++ b/pippo-demo/pippo-demo-template/src/main/resources/templates/freemarker/hello.ftl
@@ -37,8 +37,8 @@
         </div>
         <div class="panel-body">
           <ul>
-            <li><a href="${contextPath}/satisfaction">${i18n("pippo.unmatchedRoute")}</a></li>
-            <li><a href="${contextPath}/exception">${i18n("pippo.exceptionHandling")}</a></li>
+            <li><a href="${appPath}/satisfaction">${i18n("pippo.unmatchedRoute")}</a></li>
+            <li><a href="${appPath}/exception">${i18n("pippo.exceptionHandling")}</a></li>
           </ul>
         </div>
       </div>

--- a/pippo-demo/pippo-demo-template/src/main/resources/templates/jade/hello.jade
+++ b/pippo-demo/pippo-demo-template/src/main/resources/templates/jade/hello.jade
@@ -46,8 +46,8 @@ block content
         div(class="panel-body")
           ul
             li
-              a(href="#{contextPath}/satisfaction")
+              a(href="#{appPath}/satisfaction")
                 =pippo.i18n("pippo.unmatchedRoute")
             li
-              a(href="#{contextPath}/exception")
+              a(href="#{appPath}/exception")
                 =pippo.i18n("pippo.exceptionHandling")

--- a/pippo-demo/pippo-demo-template/src/main/resources/templates/pebble/hello.peb
+++ b/pippo-demo/pippo-demo-template/src/main/resources/templates/pebble/hello.peb
@@ -41,8 +41,8 @@
         </div>
         <div class="panel-body">
           <ul>
-            <li><a href="{{contextPath}}/satisfaction">{{i18n('pippo.unmatchedRoute')}}</a></li>
-            <li><a href="{{contextPath}}/exception">{{i18n('pippo.exceptionHandling')}}</a></li>
+            <li><a href="{{appPath}}/satisfaction">{{i18n('pippo.unmatchedRoute')}}</a></li>
+            <li><a href="{{appPath}}/exception">{{i18n('pippo.exceptionHandling')}}</a></li>
           </ul>
         </div>
       </div>

--- a/pippo-demo/pippo-demo-template/src/main/resources/templates/trimou/hello.mustache
+++ b/pippo-demo/pippo-demo-template/src/main/resources/templates/trimou/hello.mustache
@@ -36,8 +36,8 @@
           </div>
           <div class="panel-body">
             <ul>
-              <li><a href="{{contextPath}}/satisfaction">{{i18n 'pippo.unmatchedRoute' }}</a></li>
-              <li><a href="{{contextPath}}/exception">{{i18n 'pippo.exceptionHandling' }}</a></li>
+              <li><a href="{{appPath}}/satisfaction">{{i18n 'pippo.unmatchedRoute' }}</a></li>
+              <li><a href="{{appPath}}/exception">{{i18n 'pippo.exceptionHandling' }}</a></li>
             </ul>
           </div>
         </div>

--- a/pippo-freemarker/src/main/java/ro/pippo/freemarker/FreemarkerTemplateEngine.java
+++ b/pippo-freemarker/src/main/java/ro/pippo/freemarker/FreemarkerTemplateEngine.java
@@ -94,6 +94,7 @@ public class FreemarkerTemplateEngine implements TemplateEngine {
 
         // set global template variables
         configuration.setSharedVariable("contextPath", new SimpleScalar(router.getContextPath()));
+        configuration.setSharedVariable("appPath", new SimpleScalar(router.getApplicationPath()));
 
         webjarResourcesMethod = new WebjarsAtMethod(router);
         publicResourcesMethod = new PublicAtMethod(router);

--- a/pippo-freemarker/src/main/resources/templates/pippo/000base.ftl
+++ b/pippo-freemarker/src/main/resources/templates/pippo/000base.ftl
@@ -94,7 +94,7 @@
       <div class="application">
         ${applicationName} ${applicationVersion}
         <div>
-          <a class="link" href="${contextPath}/">&larr;</a>
+          <a class="link" href="${appPath}/">&larr;</a>
         </div>
       </div>
     </body>

--- a/pippo-groovy/src/main/java/ro/pippo/groovy/PippoGroovyTemplate.java
+++ b/pippo-groovy/src/main/java/ro/pippo/groovy/PippoGroovyTemplate.java
@@ -91,6 +91,7 @@ public abstract class PippoGroovyTemplate extends BaseTemplate {
 
         // set global template variables
         getModel().put("contextPath",  router.getContextPath());
+        getModel().put("appPath",  router.getApplicationPath());
 
         String language = (String) getModel().get(PippoConstants.REQUEST_PARAMETER_LANG);
         if (StringUtils.isNullOrEmpty(language)) {

--- a/pippo-groovy/src/main/resources/templates/pippo/000base.groovy
+++ b/pippo-groovy/src/main/resources/templates/pippo/000base.groovy
@@ -96,7 +96,7 @@ html {
         div(class:'application') {
             yield "$applicationName $applicationVersion"
             div {
-                a(class:'link', href:"$contextPath/") { yieldUnescaped '&larr;' }
+                a(class:'link', href:"$appPath/") { yieldUnescaped '&larr;' }
             }
         }
     }

--- a/pippo-jade/src/main/java/ro/pippo/jade/JadeTemplateEngine.java
+++ b/pippo-jade/src/main/java/ro/pippo/jade/JadeTemplateEngine.java
@@ -70,6 +70,7 @@ public class JadeTemplateEngine implements TemplateEngine {
 
         // set global template variables
         configuration.getSharedVariables().put("contextPath", router.getContextPath());
+        configuration.getSharedVariables().put("appPath", router.getApplicationPath());
     }
 
     public JadeConfiguration getConfiguration() {

--- a/pippo-jade/src/main/resources/templates/pippo/000base.jade
+++ b/pippo-jade/src/main/resources/templates/pippo/000base.jade
@@ -96,5 +96,5 @@ html
         div(class="application")
             #{applicationName} #{applicationVersion}
             div
-                a(class="link", href="#{contextPath}/")
+                a(class="link", href="#{appPath}/")
                     | &larr;

--- a/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
+++ b/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
@@ -95,6 +95,7 @@ public class PebbleTemplateEngine implements TemplateEngine {
 
         // set global template variables
         engine.getGlobalVariables().put("contextPath", router.getContextPath());
+        engine.getGlobalVariables().put("appPath", router.getApplicationPath());
     }
 
     @Override

--- a/pippo-pebble/src/main/resources/templates/pippo/000base.peb
+++ b/pippo-pebble/src/main/resources/templates/pippo/000base.peb
@@ -94,7 +94,7 @@
         <div class="application">
             {{applicationName}} {{applicationVersion}}
             <div>
-                <a class="link" href="{{contextPath}}/">&larr;</a>
+                <a class="link" href="{{appPath}}/">&larr;</a>
             </div>
         </div>
     </body>

--- a/pippo-trimou/src/main/java/ro/pippo/trimou/TrimouTemplateEngine.java
+++ b/pippo-trimou/src/main/java/ro/pippo/trimou/TrimouTemplateEngine.java
@@ -90,6 +90,7 @@ public class TrimouTemplateEngine implements TemplateEngine {
 
         // set global template variables
         builder.addGlobalData("contextPath", router.getContextPath());
+        builder.addGlobalData("appPath", router.getApplicationPath());
 
         engine = builder.build();
     }

--- a/pippo-trimou/src/main/resources/templates/pippo/000base.mustache
+++ b/pippo-trimou/src/main/resources/templates/pippo/000base.mustache
@@ -94,7 +94,7 @@
         <div class="application">
           {{applicationName}} {{applicationVersion}}
           <div>
-            <a class="link" href="{{contextPath}}/">&larr;</a>
+            <a class="link" href="{{appPath}}/">&larr;</a>
           </div>
         </div>
     </body>


### PR DESCRIPTION
How about this for #115?

Basic idea is to introduce an `applicationPath` which is composed of all path elements from server root to Pippo base path.  That requires adjusting Requests, Responses, TemplateEngines, etc.

The only thing I wasn't sure about was naming the template variable `${appPath}`.  If you want to change that we must be consistent across all engines.

Seems to work ok for me.  Tested with Pippo & Fathom.