### PR TITLE
maven quickstart archetype #126

### DIFF
--- a/maven-archetypes/quickstart/pom.xml
+++ b/maven-archetypes/quickstart/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ro.pippo</groupId>
+        <artifactId>pippo-parent</artifactId>
+        <version>0.5.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>pippo-quickstart</artifactId>
+    <packaging>maven-archetype</packaging>
+    <name>Pippo Quickstart Archetype</name>
+
+    <build>
+        <resources>
+            <resource>
+                <filtering>false</filtering>
+                <directory>${basedir}/src/main/resources</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </resource>
+        </resources>
+
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.archetype</groupId>
+                <artifactId>archetype-packaging</artifactId>
+                <version>2.3</version>
+            </extension>
+        </extensions>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-archetype-plugin</artifactId>
+                    <version>2.3</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/maven-archetypes/quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/maven-archetypes/quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="quickstart">
+    <fileSets>
+        <fileSet filtered="true" packaged="true" encoding="UTF-8">
+            <directory>src/main/java</directory>
+            <includes>
+                <include>**/*.java</include>
+            </includes>
+        </fileSet>
+        <fileSet filtered="false" packaged="false" encoding="UTF-8">
+            <directory>src/main/resources</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </fileSet>
+        <fileSet filtered="true" packaged="false" encoding="UTF-8">
+            <directory>src/main/webapp</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    #literal()
+    <packaging>${packaging.type}</packaging>
+    <name>quickstart</name>
+    <description>A Pippo appplication</description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <pippo.version>0.5.0-SNAPSHOT</pippo.version>
+        <slf4j.version>1.7.7</slf4j.version>
+    </properties>
+
+    <dependencies>
+        <!-- Pippo -->
+        <dependency>
+            <groupId>ro.pippo</groupId>
+            <artifactId>pippo-core</artifactId>
+            <version>${pippo.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ro.pippo</groupId>
+            <artifactId>pippo-freemarker</artifactId>
+            <version>${pippo.version}</version>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <filtering>false</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <filtering>false</filtering>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**</include>
+                </includes>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </resource>
+        </resources>
+
+        <testResources>
+            <testResource>
+                <filtering>false</filtering>
+                <directory>src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <filtering>false</filtering>
+                <directory>src/test/java</directory>
+                <includes>
+                    <include>**</include>
+                </includes>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <!--
+                    <optimize>true</optimize>
+                    -->
+                    <encoding>UTF-8</encoding>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+                <inherited>true</inherited>
+            </plugin>
+            #end
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.4.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>${package}.PippoLauncher</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    #literal()
+    <profiles>
+        <profile>
+            <id>main</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <packaging.type>jar</packaging.type>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>ro.pippo</groupId>
+                    <artifactId>pippo-jetty</artifactId>
+                    <version>${pippo.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>war</id>
+            <properties>
+                <packaging.type>war</packaging.type>
+            </properties>
+        </profile>
+    </profiles>
+    #end
+
+</project>

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/java/PippoApplication.java
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/java/PippoApplication.java
@@ -1,0 +1,53 @@
+package ${package};
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ro.pippo.core.Application;
+import ro.pippo.core.route.RouteContext;
+import ro.pippo.core.route.RouteHandler;
+
+/**
+ * A simple Pippo application.
+ *
+ * @see ${package}.PippoLauncher#main(String[])
+ */
+public class PippoApplication extends Application {
+
+    private final static Logger log = LoggerFactory.getLogger(PippoApplication.class);
+
+    @Override
+    protected void onInit() {
+        getRouter().ignorePaths("/favicon.ico");
+
+        // send 'Hello World' as response
+        GET("/", new RouteHandler() {
+
+            @Override
+            public void handle(RouteContext routeContext) {
+                routeContext.send("Hello World");
+            }
+
+        });
+
+        // send a template as response
+        GET("/template", new RouteHandler() {
+
+            @Override
+            public void handle(RouteContext routeContext) {
+                String message;
+
+                String lang = routeContext.getParameter("lang").toString();
+                if (lang == null) {
+                    message = getMessages().get("pippo.greeting", routeContext);
+                } else {
+                    message = getMessages().get("pippo.greeting", lang);
+                }
+
+                routeContext.setLocal("greeting", message);
+                routeContext.render("hello");
+            }
+
+        });
+    }
+
+}

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/java/PippoLauncher.java
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/java/PippoLauncher.java
@@ -1,0 +1,15 @@
+package ${package};
+
+import ro.pippo.core.Pippo;
+
+/**
+ * Run application from here.
+ */
+public class PippoLauncher {
+
+    public static void main(String[] args) {
+        Pippo pippo = new Pippo(new PippoApplication());
+        pippo.start();
+    }
+
+}

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/application.properties
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/application.properties
@@ -1,0 +1,38 @@
+#
+# Example application.properties file
+#
+# Add a Maven <build> filter to automatically stamp this file with your artifact metadata.
+#
+#  <build>
+#    <resources>
+#      <resource>
+#        <directory>src/main/resources</directory>
+#          <filtering>true</filtering>
+#            <includes>
+#              <include>**/*</include>
+#            </includes>
+#      </resource>
+#    </resources>
+#  </build>
+#
+
+# Specify the name and version of your application
+application.name = ${project.name}
+application.version = v${project.version}
+
+# Comma-separated list of supported languages
+# First language specified is the default
+application.languages = en, ro, de, ru, fr, es
+
+# Control the port that Pippo binds
+server.port = 8338
+
+# Control the network ip address Pippo binds
+# Specify 0.0.0.0 for all available interfaces
+server.host = localhost
+
+# Specify the context path of the application
+server.contextPath = /
+
+# Report Metrics via MBeans for VisualVM, JConsole, or JMX
+metrics.mbeans.enabled = true

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/messages.properties
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/messages.properties
@@ -1,0 +1,2 @@
+# Default messages resource
+pippo.greeting = Hello, my friend!

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/messages_de.properties
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/messages_de.properties
@@ -1,0 +1,2 @@
+# German messages resource
+pippo.greeting = Hallo, mein freund!

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/messages_es.properties
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/messages_es.properties
@@ -1,0 +1,2 @@
+# Spanish messages resource
+pippo.greeting = Hola, mi amigo!

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/messages_fr.properties
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/messages_fr.properties
@@ -1,0 +1,2 @@
+# French messages resource
+pippo.greeting = Bonjour, mon ami!

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/messages_ro.properties
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/messages_ro.properties
@@ -1,0 +1,2 @@
+# Romanian messages resource
+pippo.greeting = Buna ziua, prietenul meu!

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/messages_ru.properties
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/conf/messages_ru.properties
@@ -1,0 +1,2 @@
+# Russian messages resource
+pippo.greeting = \u041F\u0440\u0438\u0432\u0435\u0442, \u043C\u043E\u0439 \u0434\u0440\u0443\u0433

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/simplelogger.properties
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/simplelogger.properties
@@ -1,0 +1,38 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=warn
+
+# Logging detail level for a SimpleLogger instance named "xxxxx".
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, the default logging detail level is used.
+#org.slf4j.simpleLogger.log.xxxxx=
+org.slf4j.simpleLogger.log.freemarker=debug
+org.slf4j.simpleLogger.log.ro.pippo=debug
+
+# Set to true if you want the current date and time to be included in output messages.
+# Default is false, and will output the number of milliseconds elapsed since startup.
+#org.slf4j.simpleLogger.showDateTime=false
+org.slf4j.simpleLogger.showDateTime=true
+
+# The date and time format to be used in the output messages.
+# The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
+# If the format is not specified or is invalid, the default format is used.
+# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
+#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss
+
+# Set to true if you want to output the current thread name.
+# Defaults to true.
+#org.slf4j.simpleLogger.showThreadName=true
+
+# Set to true if you want the Logger instance name to be included in output messages.
+# Defaults to true.
+#org.slf4j.simpleLogger.showLogName=true
+
+# Set to true if you want the last component of the name to be included in output messages.
+# Defaults to false.
+#org.slf4j.simpleLogger.showShortLogName=false

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/templates/hello.ftl
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/resources/templates/hello.ftl
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Pippo Quickstart</title>
+    </head>
+    <body>
+        <h1>${greeting}</h1>
+    </body>
+</html>

--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+        metadata-complete="false"
+        version="3.0">
+
+    <filter>
+        <filter-name>pippo</filter-name>
+        <filter-class>ro.pippo.core.PippoFilter</filter-class>
+        <init-param>
+            <param-name>applicationClassName</param-name>
+            <param-value>${package}.PippoApplication</param-value>
+        </init-param>
+        <!--
+        <init-param>
+            <param-name>mode</param-name>
+            <param-value>dev</param-value>
+        </init-param>
+        -->
+    </filter>
+
+    <filter-mapping>
+        <filter-name>pippo</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+</web-app>


### PR DESCRIPTION
I will create a new section in pippo-site to explain how to use it.

Steps:
- install `pippo-quickstart` archetype on your computer (**OPTIONAL** - the archetype will be available soon on Maven Central Repository):
```
cd <PIPPO_HOME>/maven-archetypes/quickstart
mvn install
```
- create your quickstart project:
```
mvn archetype:generate \
  -DarchetypeGroupId=ro.pippo \
  -DarchetypeArtifactId=pippo-quickstart \
  -DarchetypeVersion=0.5.0-SNAPSHOT \
  -DgroupId=com.mycompany \
  -DartifactId=myproject
```
- run your application from command line:
```
cd myproject
mvn compile exec:java
```
now your application is available at `http://localhost:8338`

If you want to create the `war` file of your application then you must run `mvn -Pwar package`. 
`-Pwar` excludes the libraries of the embedded web server from the war file. 
