### PR TITLE
Add support for 1-dimensional collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#124]: Automatically encode the parameters values in DefaultRouter.uriFor()
 - [#126]: Maven quickstart archetype to build a small Pippo web application
 - [#128]: Added support for `Set`, `List`, and any other concrete Collection type
+- [#128]: Added support for array query/form parameters like `yada[0]`, `yada[1]`, & `yada[2]`
 
 #### Removed
 - Removed pippo-ioc module because it is no longer used anywhere

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#121]: Added [pippo-jackson]
 - [#124]: Automatically encode the parameters values in DefaultRouter.uriFor()
 - [#126]: Maven quickstart archetype to build a small Pippo web application
+- [#128]: Added support for `Set`, `List`, and any other concrete Collection type
 
 #### Removed
 - Removed pippo-ioc module because it is no longer used anywhere

--- a/pippo-controller/src/main/java/ro/pippo/controller/DefaultControllerHandler.java
+++ b/pippo-controller/src/main/java/ro/pippo/controller/DefaultControllerHandler.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -214,9 +215,20 @@ public class DefaultControllerHandler implements ControllerHandler {
     }
 
     protected Class<?> getParameterGenericType(Method method, int i) {
-        ParameterizedType parameterizedType = (ParameterizedType) method.getGenericParameterTypes()[i];
-        Class<?> genericType = (Class<?>) parameterizedType.getActualTypeArguments()[0];
-        return genericType;
+        Type genericType = method.getGenericParameterTypes()[i];
+        if (!ParameterizedType.class.isAssignableFrom(genericType.getClass())) {
+            throw new PippoRuntimeException("Please specify a generic parameter type for '{}', parameter {} of '{}'",
+                method.getParameterTypes()[i].getName(), i, LangUtils.toString(method));
+        }
+
+        ParameterizedType parameterizedType = (ParameterizedType) genericType;
+        try {
+            Class<?> genericClass = (Class<?>) parameterizedType.getActualTypeArguments()[0];
+            return genericClass;
+        } catch (ClassCastException e) {
+            throw new PippoRuntimeException("Please specify a generic parameter type for '{}', parameter {} of '{}'",
+                method.getParameterTypes()[i].getName(), i, LangUtils.toString(method));
+        }
     }
 
     protected boolean isBodyParameter(Method method, int i) {

--- a/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
@@ -28,7 +28,10 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 
 /**
@@ -158,8 +161,50 @@ public class ParameterValueTest extends Assert {
 
 
     @Test
-    public void testList() throws Exception {
+    public void testStringList() throws Exception {
         assertEquals(Arrays.asList("A", "B", "C"), new ParameterValue("A", "B", "C").toList());
+    }
+
+    @Test
+    public void testIntegerList() throws Exception {
+        assertEquals(Arrays.asList(200, 400, 600), new ParameterValue("200", "400", "600").toList(Integer.class));
+    }
+
+    @Test
+    public void testStringHashSet() throws Exception {
+        Set<String> mySet = new HashSet<>(Arrays.asList("A", "B", "C"));
+        Set<String> targetSet = new ParameterValue("C", "B", "A").toSet(String.class);
+        assertEquals(mySet, targetSet);
+    }
+
+    @Test
+    public void testIntegerHashSet() throws Exception {
+        Set<Integer> mySet = new HashSet<>(Arrays.asList(200, 400, 600));
+        assertEquals(mySet, new ParameterValue("600", "200", "400", "200").toSet(Integer.class));
+    }
+
+    @Test
+    public void testStringTreeSet() throws Exception {
+        TreeSet<String> mySet = new TreeSet<>(Arrays.asList("C", "B", "A"));
+        assertEquals(mySet, new ParameterValue("C", "A", "B", "A").toCollection(TreeSet.class, String.class, null));
+    }
+
+    @Test
+    public void testIntegerTreeSet() throws Exception {
+        TreeSet<Integer> mySet = new TreeSet<>(Arrays.asList(600, 200, 400, 200));
+        assertEquals(mySet, new ParameterValue("600", "200", "400", "200").toCollection(TreeSet.class, Integer.class, null));
+    }
+
+    @Test
+    public void testStringArrayList() throws Exception {
+        List<String> myList = new ArrayList<>(Arrays.asList("C", "B", "A"));
+        assertEquals(myList, new ParameterValue("C", "B", "A").toList(String.class));
+    }
+
+    @Test
+    public void testIntegerArrayList() throws Exception {
+        List<Integer> myList = new ArrayList<>(Arrays.asList(600, 400, 200));
+        assertEquals(myList, new ParameterValue("600", "400", "200").toList(Integer.class));
     }
 
     @Test

--- a/pippo-demo/pippo-demo-controller/src/main/java/ro/pippo/demo/controller/CollectionsController.java
+++ b/pippo-demo/pippo-demo-controller/src/main/java/ro/pippo/demo/controller/CollectionsController.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.demo.controller;
+
+import ro.pippo.controller.Controller;
+import ro.pippo.core.Param;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * @author James Moger
+ */
+public class CollectionsController extends Controller {
+
+    public void index() {
+        getResponse()
+            .bind("mySet", Arrays.asList(2, 2, 4, 4, 6, 6, 8, 8))
+            .bind("myList", Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8))
+            .bind("myTreeSet", Arrays.asList(7, 5, 7, 5, 3, 1, 3, 1))
+            .render("collections");
+    }
+
+    public void update(@Param("mySet") Set<Integer> mySet,
+                       @Param("myList") List<Integer> myList,
+                       @Param("myTreeSet") TreeSet<String> treeSet) {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("mySet=").append(mySet.toString()).append('\n');
+        sb.append("myList=").append(myList.toString()).append('\n');
+        sb.append("myTreeSet=").append(treeSet.toString()).append('\n');
+        getResponse().text().send(sb.toString());
+    }
+
+}

--- a/pippo-demo/pippo-demo-controller/src/main/java/ro/pippo/demo/controller/ControllerApplication.java
+++ b/pippo-demo/pippo-demo-controller/src/main/java/ro/pippo/demo/controller/ControllerApplication.java
@@ -31,6 +31,9 @@ public class ControllerApplication extends ro.pippo.controller.ControllerApplica
 
         GET("/", ContactsController.class, "index");
         GET("/contact/{id}", ContactsController.class, "uriFor");
+
+        GET("/collections", CollectionsController.class, "index");
+        POST("/collections", CollectionsController.class, "update");
     }
 
 }

--- a/pippo-demo/pippo-demo-controller/src/main/resources/templates/collections.ftl
+++ b/pippo-demo/pippo-demo-controller/src/main/resources/templates/collections.ftl
@@ -1,0 +1,39 @@
+<#import "base.ftl" as base/>
+<@base.page title="Collections">
+    <div class="page-header">
+        <h2>Collections <small>POST with indexed-parameter form url-encoding</small></h2>
+    </div>
+
+    <form class="form-horizontal" role="form" method="post">
+        <div class="form-group">
+            <label for="mySet[0]" class="col-sm-2 control-label">Set</label>
+            <div class="col-sm-9">
+                <#list mySet as value>
+                    <input class="form-control" id="mySet[${value_index}]" name="mySet[${value_index}]" value="${value}">
+                </#list>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="myList[0]"  class="col-sm-2 control-label">List</label>
+            <div class="col-sm-9">
+                <#list myList as value>
+                    <input class="form-control" id="myList[${value_index}]" name="myList[${value_index}]" value="${value}">
+                </#list>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="myTreeSet[0]" class="col-sm-2 control-label">TreeSet</label>
+            <div class="col-sm-9">
+                <#list myTreeSet as value>
+                    <input class="form-control" id="myTreeSet[${value_index}]" name="myTreeSet[${value_index}]" value="${value}">
+                </#list>
+            </div>
+        </div>
+        <div class="form-group">
+            <div class="col-sm-offset-2 col-sm-9">
+                <button type="submit" class="btn btn-default btn-primary">Submit</button>
+                <a type="submit" class="btn" href="${appPath}">Cancel</a>
+            </div>
+        </div>
+    </form>
+</@base.page>


### PR DESCRIPTION
This adds support for things like `List`, `Set`, and `TreeSet`.  The implementation covers Controllers and direct ParameterValue access from `RouteHandler`.  To compliment this feature, the `Request` will now recognize and assemble indexed-parameters.