### PR TITLE
Allow html forms to specify _method which overrides the servlet method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#126]: Maven quickstart archetype to build a small Pippo web application
 - [#128]: Added support for `Set`, `List`, and any other concrete Collection type
 - [#128]: Added support for array query/form parameters like `yada[0]`, `yada[1]`, & `yada[2]`
+- [#129]: Added support for `_method` assignment for HTML form POST processing
 
 #### Removed
 - Removed pippo-ioc module because it is no longer used anywhere

--- a/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
@@ -133,7 +133,7 @@ public class PippoFilter implements Filter {
             return;
         }
 
-        log.debug("Request {} '{}'", httpServletRequest.getMethod(), requestPath);
+        log.debug("Request {} '{}'", request.getMethod(), requestPath);
 
         // dispatch route(s)
         routeDispatcher.dispatch(request, response);

--- a/pippo-core/src/main/java/ro/pippo/core/PippoServlet.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoServlet.java
@@ -113,7 +113,7 @@ public class PippoServlet extends HttpServlet {
 
         log.trace("The relative path for '{}' is '{}'", requestUri, requestPath);
 
-        log.debug("Request {} '{}'", httpServletRequest.getMethod(), requestPath);
+        log.debug("Request {} '{}'", request.getMethod(), requestPath);
 
         // dispatch route(s)
         routeDispatcher.dispatch(request, response);

--- a/pippo-core/src/main/java/ro/pippo/core/Request.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Request.java
@@ -57,6 +57,7 @@ public final class Request {
     private Map<String, FileItem> files;
     private Session session;
     private String applicationPath;
+    private String method;
     private String path;
 
     private String body; // cache
@@ -377,7 +378,16 @@ public final class Request {
     }
 
     public String getMethod() {
-        return httpServletRequest.getMethod();
+        if (method == null) {
+            method = httpServletRequest.getMethod();
+            if (HttpConstants.Method.POST.equals(method)
+                && (HttpConstants.ContentType.APPLICATION_FORM_URLENCODED.equals(getContentType())
+                || HttpConstants.ContentType.MULTIPART_FORM_DATA.equals(getContentType()))) {
+                // allow forms to submit with spoofed http methods, similar to Rails & Django
+                method = getParameter("_method").toString(method).toUpperCase();
+            }
+        }
+        return method;
     }
 
     public HttpServletRequest getHttpServletRequest() {

--- a/pippo-core/src/main/java/ro/pippo/core/route/CSRFHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/CSRFHandler.java
@@ -102,8 +102,9 @@ public class CSRFHandler implements RouteHandler<RouteContext> {
 
     @Override
     public void handle(RouteContext context) {
-
-        if (HttpConstants.Method.POST.equals(context.getRequestMethod())) {
+        // obtain the servlet http method because Pippo allows method spoofing
+        String rawMethod = context.getRequest().getHttpServletRequest().getMethod();
+        if (HttpConstants.Method.POST.equals(rawMethod)) {
 
             // Verify the content-type is guarded
             String contentType = new ParameterValue(context.getHeader("Content-Type")).toString("").toLowerCase();
@@ -136,7 +137,7 @@ public class CSRFHandler implements RouteHandler<RouteContext> {
 
             log.debug("Validated '{}' for {} '{}'", TOKEN, context.getRequestMethod(), context.getRequestUri());
 
-        } else if (HttpConstants.Method.GET.equals(context.getRequestMethod())) {
+        } else if (HttpConstants.Method.GET.equals(rawMethod)) {
 
             // Generate a CSRF session token on reads
             if (getSessionCsrfToken(context) == null) {

--- a/pippo-demo/pippo-demo-controller/src/main/java/ro/pippo/demo/controller/CollectionsController.java
+++ b/pippo-demo/pippo-demo-controller/src/main/java/ro/pippo/demo/controller/CollectionsController.java
@@ -31,8 +31,8 @@ public class CollectionsController extends Controller {
     public void index() {
         getResponse()
             .bind("mySet", Arrays.asList(2, 2, 4, 4, 6, 6, 8, 8))
-            .bind("myList", Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8))
-            .bind("myTreeSet", Arrays.asList(7, 5, 7, 5, 3, 1, 3, 1))
+            .bind("myList", Arrays.asList(1945, 1955, 1965, 1975, 1985, 1995, 2005, 2015))
+            .bind("myTreeSet", Arrays.asList("Blue", "Orange", "Blue", "Orange", "Red", "Green", "Red", "Green"))
             .render("collections");
     }
 

--- a/pippo-demo/pippo-demo-controller/src/main/java/ro/pippo/demo/controller/ControllerApplication.java
+++ b/pippo-demo/pippo-demo-controller/src/main/java/ro/pippo/demo/controller/ControllerApplication.java
@@ -33,7 +33,7 @@ public class ControllerApplication extends ro.pippo.controller.ControllerApplica
         GET("/contact/{id}", ContactsController.class, "uriFor");
 
         GET("/collections", CollectionsController.class, "index");
-        POST("/collections", CollectionsController.class, "update");
+        PUT("/collections", CollectionsController.class, "update");
     }
 
 }

--- a/pippo-demo/pippo-demo-controller/src/main/resources/templates/collections.ftl
+++ b/pippo-demo/pippo-demo-controller/src/main/resources/templates/collections.ftl
@@ -1,36 +1,34 @@
 <#import "base.ftl" as base/>
 <@base.page title="Collections">
     <div class="page-header">
-        <h2>Collections <small>POST with indexed-parameter form url-encoding</small></h2>
+        <h2>Collections <small>POST[PUT] with indexed-parameter form url-encoding</small></h2>
     </div>
 
     <form class="form-horizontal" role="form" method="post">
         <div class="form-group">
-            <label for="mySet[0]" class="col-sm-2 control-label">Set</label>
-            <div class="col-sm-9">
+            <div class="col-sm-4">
+                <h4>Set&lt;Integer&gt;</h4>
                 <#list mySet as value>
-                    <input class="form-control" id="mySet[${value_index}]" name="mySet[${value_index}]" value="${value}">
+                    <input type="text" class="form-control" id="mySet[${value_index}]" name="mySet[${value_index}]" value="${value}">
                 </#list>
             </div>
-        </div>
-        <div class="form-group">
-            <label for="myList[0]"  class="col-sm-2 control-label">List</label>
-            <div class="col-sm-9">
+            <div class="col-sm-4">
+                <h4>List&lt;Integer&gt;</h4>
                 <#list myList as value>
-                    <input class="form-control" id="myList[${value_index}]" name="myList[${value_index}]" value="${value}">
+                    <input type="text" class="form-control" id="myList[${value_index}]" name="myList[${value_index}]" value="${value}">
                 </#list>
             </div>
-        </div>
-        <div class="form-group">
-            <label for="myTreeSet[0]" class="col-sm-2 control-label">TreeSet</label>
-            <div class="col-sm-9">
+            <div class="col-sm-4">
+                <h4>TreeSet&lt;String&gt;</h4>
                 <#list myTreeSet as value>
-                    <input class="form-control" id="myTreeSet[${value_index}]" name="myTreeSet[${value_index}]" value="${value}">
+                    <input type="text" class="form-control" id="myTreeSet[${value_index}]" name="myTreeSet[${value_index}]" value="${value}">
                 </#list>
             </div>
         </div>
         <div class="form-group">
-            <div class="col-sm-offset-2 col-sm-9">
+            <div class="col-sm-4">
+                <!-- Specify the PUT method. Pippo will receive the POST and will route to the PUT handler. -->
+                <input type="hidden" name="_method" value="PUT">
                 <button type="submit" class="btn btn-default btn-primary">Submit</button>
                 <a type="submit" class="btn" href="${appPath}">Cancel</a>
             </div>


### PR DESCRIPTION
This is the same useful behavior found in Rails and Django.  It allows for applying a more RESTful design to standard form processing.  To use it, specify a hidden input field named `_method` with a value of the preferred http method (e.g. `PATCH`, `PUT`, `DELETE`, etc).  Pippo will automatically route the POSTed request to the preferred handler.  The Collections controller example has been updated to use `PUT` as a demonstration.