### PR TITLE
Jetty-9 default values

### DIFF
--- a/pippo-jetty/src/main/java/ro/pippo/jetty/JettySettings.java
+++ b/pippo-jetty/src/main/java/ro/pippo/jetty/JettySettings.java
@@ -27,8 +27,8 @@ public class JettySettings extends WebServerSettings {
     public static final String MIN_THREADS = "jetty.minThreads";
     public static final String IDLE_TIMEOUT = "jetty.idleTimeout";
 
-    private int maxThreads = 100;
-    private int minThreads = 10;
+    private int maxThreads = 200;
+    private int minThreads = 8;
     private int idleTimeout = 30000; // in miliseconds
 
     public JettySettings(PippoSettings pippoSettings) {


### PR DESCRIPTION
If not configured, use jetty-9 default values for threads.
