### PR TITLE
add route name as first criterion in urlFor

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouteContext.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouteContext.java
@@ -325,8 +325,8 @@ public class DefaultRouteContext implements RouteContext {
     }
 
     @Override
-    public String uriFor(String uriPattern, Map<String, Object> parameters) {
-        return application.getRouter().uriFor(uriPattern, parameters);
+    public String uriFor(String nameOrUriPattern, Map<String, Object> parameters) {
+        return application.getRouter().uriFor(nameOrUriPattern, parameters);
     }
 
     @SuppressWarnings("unchecked")

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -214,13 +214,13 @@ public class DefaultRouter implements Router {
      * </pre>
      * The parameters values are automatically encoded by this method.
      *
-     * @param uriPattern
+     * @param nameOrUriPattern
      * @param parameters
      * @return
      */
     @Override
-    public String uriFor(String uriPattern, Map<String, Object> parameters) {
-        PatternBinding binding = getBinding(uriPattern);
+    public String uriFor(String nameOrUriPattern, Map<String, Object> parameters) {
+        PatternBinding binding = getBinding(nameOrUriPattern);
 
         return (binding != null) ? prefixApplicationPath(uriFor(binding, parameters)) : null;
     }
@@ -276,15 +276,15 @@ public class DefaultRouter implements Router {
     }
 
     private void removeBinding(Route route) {
-        PatternBinding binding = getBinding(route.getUriPattern());
+        PatternBinding binding = getBinding(route.getNameOrUriPattern());
         bindingsCache.get(route.getRequestMethod()).remove(binding);
     }
 
-    private PatternBinding getBinding(String uriPattern) {
+    private PatternBinding getBinding(String nameOrUriPattern) {
         Collection<List<PatternBinding>> values = bindingsCache.values();
         for (List<PatternBinding> bindings : values) {
             for (PatternBinding binding : bindings) {
-                if (uriPattern.equals(binding.getRoute().getUriPattern())) {
+                if (nameOrUriPattern.equals(binding.getRoute().getNameOrUriPattern())) {
                     return binding;
                 }
             }

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -276,15 +276,18 @@ public class DefaultRouter implements Router {
     }
 
     private void removeBinding(Route route) {
-        PatternBinding binding = getBinding(route.getNameOrUriPattern());
+        String nameOrUriPattern = StringUtils.isNullOrEmpty(route.getName()) ? route.getUriPattern() : route.getName();
+        PatternBinding binding = getBinding(nameOrUriPattern);
         bindingsCache.get(route.getRequestMethod()).remove(binding);
     }
 
     private PatternBinding getBinding(String nameOrUriPattern) {
         Collection<List<PatternBinding>> values = bindingsCache.values();
+        Route route;
         for (List<PatternBinding> bindings : values) {
             for (PatternBinding binding : bindings) {
-                if (nameOrUriPattern.equals(binding.getRoute().getNameOrUriPattern())) {
+                route = binding.getRoute();
+                if (nameOrUriPattern.equals(route.getName()) || nameOrUriPattern.equals(route.getUriPattern())) {
                     return binding;
                 }
             }

--- a/pippo-core/src/main/java/ro/pippo/core/route/Route.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Route.java
@@ -15,8 +15,6 @@
  */
 package ro.pippo.core.route;
 
-import ro.pippo.core.util.StringUtils;
-
 /**
  * @author Decebal Suiu
  */
@@ -70,10 +68,6 @@ public class Route {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public String getNameOrUriPattern() {
-        return StringUtils.isNullOrEmpty(name) ? uriPattern : name;
     }
 
     @Override

--- a/pippo-core/src/main/java/ro/pippo/core/route/Route.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Route.java
@@ -15,6 +15,8 @@
  */
 package ro.pippo.core.route;
 
+import ro.pippo.core.util.StringUtils;
+
 /**
  * @author Decebal Suiu
  */
@@ -68,6 +70,10 @@ public class Route {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getNameOrUriPattern() {
+        return StringUtils.isNullOrEmpty(name) ? uriPattern : name;
     }
 
     @Override

--- a/pippo-core/src/main/java/ro/pippo/core/route/RouteContext.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/RouteContext.java
@@ -115,6 +115,6 @@ public interface RouteContext {
 
     public RouteContext status(int code);
 
-    public String uriFor(String uriPattern, Map<String, Object> parameters);
+    public String uriFor(String nameOrUriPattern, Map<String, Object> parameters);
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/route/Router.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Router.java
@@ -62,7 +62,7 @@ public interface Router {
      */
     public String uriFor(String relativeUri);
 
-    public String uriFor(String uriPattern, Map<String, Object> parameters);
+    public String uriFor(String nameOrUriPattern, Map<String, Object> parameters);
 
     public String uriPatternFor(Class<? extends StaticResourceHandler> resourceHandlerClass);
 

--- a/pippo-demo/pippo-demo-ajax/src/main/java/ro/pippo/demo/ajax/AjaxApplication.java
+++ b/pippo-demo/pippo-demo-ajax/src/main/java/ro/pippo/demo/ajax/AjaxApplication.java
@@ -101,6 +101,7 @@ public class AjaxApplication extends Application {
                 if (id > 0) {
                     parameters.put("id", id);
                 }
+//                routeContext.setLocal("saveUrl", getRouter().uriFor("/contact", parameters));
                 routeContext.setLocal("saveUrl", getRouter().uriFor("postContact", parameters));
 
                 routeContext.render("view/contact");

--- a/pippo-demo/pippo-demo-ajax/src/main/java/ro/pippo/demo/ajax/AjaxApplication.java
+++ b/pippo-demo/pippo-demo-ajax/src/main/java/ro/pippo/demo/ajax/AjaxApplication.java
@@ -101,7 +101,7 @@ public class AjaxApplication extends Application {
                 if (id > 0) {
                     parameters.put("id", id);
                 }
-                routeContext.setLocal("saveUrl", getRouter().uriFor("/contact", parameters));
+                routeContext.setLocal("saveUrl", getRouter().uriFor("postContact", parameters));
 
                 routeContext.render("view/contact");
             }
@@ -120,7 +120,7 @@ public class AjaxApplication extends Application {
                 routeContext.render("view/contacts");
             }
 
-        });
+        }).named("postContact");
 
         DELETE("/contact/{id}", new RouteHandler() {
 


### PR DESCRIPTION
I try to implements the idea from the comment https://github.com/decebals/pippo/pull/99#issuecomment-77233748

In few words I can add a route (in an hypothetical blog application) with:
```java
GET("/blogs/{year}/{month}/{day}/{title}", (routeContext) -> { routeContext.render("myTemplate)});
```

It's hard to create the reverse routing using the `uriPattern`:
```java
Map<String, Object> parameters = ...
routeContext.uriFor("/blogs/{year}/{month}/{day}/{title}", parameters);
```

Now you can add a `name` for a route and to use this name when you build the URL(reverse routing) to that route:
```java
GET("/blogs/{year}/{month}/{day}/{title}", (routeContext) -> { routeContext.render("myTemplate)}).named("blog");
```

The new cod becomes:
```java
Map<String, Object> parameters = ...
routeContext.uriFor("blog", parameters);
```

Advantages:
- it is often more descriptive than hard-coding the `uriPattern`
- it allows you to change `uriPattern` in one go, without having to remember to change URLs all over the place.

I will try to add the same approach for `redirect`.

What you say?