### PR TITLE
Improve array support in ParameterValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated [pippo-undertow] to Undertow 1.2.8
 - Updated [pippo-jackson] to Jackson 2.5.4
 - [#152]: Rename maven profile `main` with `standalone` for clearer usage
+- Improved support for array types in ParameterValue
 
 #### Added
 - [#35]: Added demo ajax using intercooler.js [pippo-demo-ajax]

--- a/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
@@ -226,6 +226,36 @@ public class ParameterValueTest extends Assert {
     }
 
     @Test
+    public void testEncodedArrayList2() throws Exception {
+        List<Integer> myList = new ArrayList<>(Arrays.asList(600, 400, 200));
+        assertEquals(myList, new ParameterValue("600, 400,200").toList(Integer.class));
+    }
+
+    @Test
+    public void testEncodedArrayList3() throws Exception {
+        List<Integer> myList = new ArrayList<>(Arrays.asList(600, 400, 200));
+        assertEquals(myList, new ParameterValue("600| 400|200").toList(Integer.class));
+    }
+
+    @Test
+    public void testEncodedArray() throws Exception {
+        int [] myArray = { 600, 400, 200 };
+        assertTrue(Arrays.equals(myArray, new ParameterValue("[600, 400, 200]").to(int[].class)));
+    }
+
+    @Test
+    public void testEncodedArray2() throws Exception {
+        int [] myArray = { 600, 400, 200 };
+        assertTrue(Arrays.equals(myArray, new ParameterValue("600, 400,200").to(int[].class)));
+    }
+
+    @Test
+    public void testEncodedArray3() throws Exception {
+        int [] myArray = { 600, 400, 200 };
+        assertTrue(Arrays.equals(myArray, new ParameterValue("600| 400|200").to(int[].class)));
+    }
+
+    @Test
     public void testEnums() throws Exception {
         assertEquals(Alphabet.B, new ParameterValue("B").toEnum(Alphabet.class));
         assertEquals(Alphabet.B, new ParameterValue("B", "A", "D").toEnum(Alphabet.class));


### PR DESCRIPTION
This PR adds improved support for array extraction from ParameterValue.

```java
Arrays.equals(new int [] {1,2,3,4,5}, new ParameterValue("1|2|3|4|5").to(int[].class));
Arrays.equals(new int [] {1,2,3,4,5}, new ParameterValue("1,2,3,4,5").to(int[].class));
```