### PR TITLE
Serialize and deserialize date, time, and datetime using ISO8601 in Gson

### DIFF
--- a/pippo-gson/pom.xml
+++ b/pippo-gson/pom.xml
@@ -31,6 +31,13 @@
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pippo-gson/src/main/java/ro/pippo/gson/GsonEngine.java
+++ b/pippo-gson/src/main/java/ro/pippo/gson/GsonEngine.java
@@ -35,7 +35,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
-import java.util.TimeZone;
 
 /**
  * A JsonEngine based on Gson.
@@ -65,18 +64,17 @@ public class GsonEngine implements ContentTypeEngine {
 
     private Gson gson() {
         return new GsonBuilder()
-            .registerTypeAdapter(Date.class, new ISO8601UTCDateTimeTypeAdapter())
-            .registerTypeAdapter(Time.class, new ISO8601UTCTimeTypeAdapter())
-            .registerTypeAdapter(java.sql.Date.class, new ISO8601UTCDateTypeAdapter())
+            .registerTypeAdapter(Date.class, new ISO8601DateTimeTypeAdapter())
+            .registerTypeAdapter(Time.class, new ISO8601TimeTypeAdapter())
+            .registerTypeAdapter(java.sql.Date.class, new ISO8601DateTypeAdapter())
             .create();
     }
 
-    public static class ISO8601UTCDateTypeAdapter implements JsonSerializer<java.sql.Date>, JsonDeserializer<java.sql.Date> {
+    public static class ISO8601DateTypeAdapter implements JsonSerializer<java.sql.Date>, JsonDeserializer<java.sql.Date> {
         private final DateFormat dateFormat;
 
-        public ISO8601UTCDateTypeAdapter() {
+        public ISO8601DateTypeAdapter() {
             dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
-            dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         }
 
         @Override
@@ -102,12 +100,11 @@ public class GsonEngine implements ContentTypeEngine {
         }
     }
 
-    public static class ISO8601UTCTimeTypeAdapter implements JsonSerializer<Time>, JsonDeserializer<Time> {
+    public static class ISO8601TimeTypeAdapter implements JsonSerializer<Time>, JsonDeserializer<Time> {
         private final DateFormat timeFormat;
 
-        public ISO8601UTCTimeTypeAdapter() {
-            timeFormat = new SimpleDateFormat("HH:mm:ss'Z'", Locale.US);
-            timeFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        public ISO8601TimeTypeAdapter() {
+            timeFormat = new SimpleDateFormat("HH:mm:ssZ", Locale.US);
         }
 
         @Override
@@ -121,7 +118,7 @@ public class GsonEngine implements ContentTypeEngine {
 
         @Override
         public synchronized Time deserialize(JsonElement jsonElement, Type type,
-                                                      JsonDeserializationContext jsonDeserializationContext) {
+                                             JsonDeserializationContext jsonDeserializationContext) {
             try {
                 synchronized (timeFormat) {
                     Date date = timeFormat.parse(jsonElement.getAsString());
@@ -133,12 +130,11 @@ public class GsonEngine implements ContentTypeEngine {
         }
     }
 
-    public static class ISO8601UTCDateTimeTypeAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
+    public static class ISO8601DateTimeTypeAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
         private final DateFormat dateTimeFormat;
 
-        public ISO8601UTCDateTimeTypeAdapter() {
-            dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
-            dateTimeFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        public ISO8601DateTimeTypeAdapter() {
+            dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
         }
 
         @Override

--- a/pippo-gson/src/main/java/ro/pippo/gson/GsonEngine.java
+++ b/pippo-gson/src/main/java/ro/pippo/gson/GsonEngine.java
@@ -15,11 +15,27 @@
  */
 package ro.pippo.gson;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonSyntaxException;
 import ro.pippo.core.Application;
 import ro.pippo.core.ContentTypeEngine;
 import ro.pippo.core.HttpConstants;
 
-import com.google.gson.Gson;
+import java.lang.reflect.Type;
+import java.sql.Time;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * A JsonEngine based on Gson.
@@ -28,23 +44,123 @@ import com.google.gson.Gson;
  */
 public class GsonEngine implements ContentTypeEngine {
 
-	@Override
-	public void init(Application application) {
-	}
+    @Override
+    public void init(Application application) {
+    }
 
     @Override
     public String getContentType() {
         return HttpConstants.ContentType.APPLICATION_JSON;
     }
 
-	@Override
-	public String toString(Object object) {
-		return new Gson().toJson(object);
-	}
+    @Override
+    public String toString(Object object) {
+        return gson().toJson(object);
+    }
 
-	@Override
-	public <T> T fromString(String content, Class<T> classOfT) {
-		return new Gson().fromJson(content, classOfT);
-	}
+    @Override
+    public <T> T fromString(String content, Class<T> classOfT) {
+        return gson().fromJson(content, classOfT);
+    }
 
+    private Gson gson() {
+        return new GsonBuilder()
+            .registerTypeAdapter(Date.class, new ISO8601UTCDateTimeTypeAdapter())
+            .registerTypeAdapter(Time.class, new ISO8601UTCTimeTypeAdapter())
+            .registerTypeAdapter(java.sql.Date.class, new ISO8601UTCDateTypeAdapter())
+            .create();
+    }
+
+    public static class ISO8601UTCDateTypeAdapter implements JsonSerializer<java.sql.Date>, JsonDeserializer<java.sql.Date> {
+        private final DateFormat dateFormat;
+
+        public ISO8601UTCDateTypeAdapter() {
+            dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+            dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        }
+
+        @Override
+        public synchronized JsonElement serialize(java.sql.Date date, Type type,
+                                                  JsonSerializationContext jsonSerializationContext) {
+            synchronized (dateFormat) {
+                String dateFormatAsString = dateFormat.format(date);
+                return new JsonPrimitive(dateFormatAsString);
+            }
+        }
+
+        @Override
+        public synchronized java.sql.Date deserialize(JsonElement jsonElement, Type type,
+                                                      JsonDeserializationContext jsonDeserializationContext) {
+            try {
+                synchronized (dateFormat) {
+                    Date date = dateFormat.parse(jsonElement.getAsString());
+                    return new java.sql.Date((date.getTime() / 1000) * 1000);
+                }
+            } catch (ParseException e) {
+                throw new JsonSyntaxException(jsonElement.getAsString(), e);
+            }
+        }
+    }
+
+    public static class ISO8601UTCTimeTypeAdapter implements JsonSerializer<Time>, JsonDeserializer<Time> {
+        private final DateFormat timeFormat;
+
+        public ISO8601UTCTimeTypeAdapter() {
+            timeFormat = new SimpleDateFormat("HH:mm:ss'Z'", Locale.US);
+            timeFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        }
+
+        @Override
+        public synchronized JsonElement serialize(Time time, Type type,
+                                                  JsonSerializationContext jsonSerializationContext) {
+            synchronized (timeFormat) {
+                String timeFormatAsString = timeFormat.format(time);
+                return new JsonPrimitive(timeFormatAsString);
+            }
+        }
+
+        @Override
+        public synchronized Time deserialize(JsonElement jsonElement, Type type,
+                                                      JsonDeserializationContext jsonDeserializationContext) {
+            try {
+                synchronized (timeFormat) {
+                    Date date = timeFormat.parse(jsonElement.getAsString());
+                    return new Time((date.getTime() / 1000) * 1000);
+                }
+            } catch (ParseException e) {
+                throw new JsonSyntaxException(jsonElement.getAsString(), e);
+            }
+        }
+    }
+
+    public static class ISO8601UTCDateTimeTypeAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
+        private final DateFormat dateTimeFormat;
+
+        public ISO8601UTCDateTimeTypeAdapter() {
+            dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+            dateTimeFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        }
+
+        @Override
+        public synchronized JsonElement serialize(Date date, Type type,
+                                                  JsonSerializationContext jsonSerializationContext) {
+            synchronized (dateTimeFormat) {
+                String dateFormatAsString = dateTimeFormat.format(date);
+                return new JsonPrimitive(dateFormatAsString);
+            }
+        }
+
+        @Override
+        public synchronized Date deserialize(JsonElement jsonElement, Type type,
+                                             JsonDeserializationContext jsonDeserializationContext) {
+            try {
+                synchronized (dateTimeFormat) {
+                    Date date = dateTimeFormat.parse(jsonElement.getAsString());
+                    return new Date((date.getTime() / 1000) * 1000);
+                }
+            } catch (ParseException e) {
+                throw new JsonSyntaxException(jsonElement.getAsString(), e);
+            }
+        }
+    }
 }

--- a/pippo-gson/src/main/test/ro/pippo/gson/GsonEngineTest.java
+++ b/pippo-gson/src/main/test/ro/pippo/gson/GsonEngineTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.gson;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * @author James Moger
+ */
+public class GsonEngineTest extends Assert {
+
+    @Test
+    public void testEngine() {
+        MyTest test = new MyTest();
+
+        GsonEngine engine = new GsonEngine();
+        String json = engine.toString(test);
+
+        MyTest result = engine.fromString(json, MyTest.class);
+        assertEquals(test.message, result.message);
+    }
+
+    @Test
+    public void testDates() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.MILLISECOND, 0);
+        Date now = cal.getTime();
+
+        MyTest test = new MyTest();
+        test.date = now;
+
+        GsonEngine engine = new GsonEngine();
+        String json = engine.toString(test);
+
+        MyTest result = engine.fromString(json, MyTest.class);
+        assertEquals(test.message, result.message);
+
+        assertTrue(test.date.equals(result.date));
+    }
+
+    public static class MyTest {
+
+        public String message = "Hooray!";
+
+        public Date date = new Date();
+
+    }
+}


### PR DESCRIPTION
This PR specifies ISO8601 date & time formatters for the Gson engine.  The current implementation leaves date & time serialization to a locally formatted , non-standard string.  This proposal uses a standard date/time interchange format.

https://en.wikipedia.org/wiki/ISO_8601