### PR TITLE
Split JAXB engine into a separate module

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/Application.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Application.java
@@ -88,7 +88,6 @@ public class Application {
         this.initializers = new ArrayList<>();
 
         registerContentTypeEngine(TextPlainEngine.class);
-        registerContentTypeEngine(JaxbEngine.class);
     }
 
     public final void init() {

--- a/pippo-demo/pom.xml
+++ b/pippo-demo/pom.xml
@@ -68,6 +68,11 @@
                     <artifactId>pippo-jetty</artifactId>
                     <version>${project.version}</version>
                 </dependency>
+                <dependency>
+                    <groupId>ro.pippo</groupId>
+                    <artifactId>pippo-jaxb</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
             </dependencies>
         </profile>
         <profile>

--- a/pippo-jaxb/pom.xml
+++ b/pippo-jaxb/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>ro.pippo</groupId>
+        <artifactId>pippo-parent</artifactId>
+        <version>0.6.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <artifactId>pippo-jaxb</artifactId>
+    <version>0.6.0-SNAPSHOT</version>
+    <name>Pippo JAXB</name>
+    <description>JAXB integration</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ro.pippo</groupId>
+            <artifactId>pippo-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pippo-jaxb/src/main/java/ro/pippo/jaxb/JaxbEngine.java
+++ b/pippo-jaxb/src/main/java/ro/pippo/jaxb/JaxbEngine.java
@@ -13,15 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ro.pippo.core;
+package ro.pippo.jaxb;
 
-import java.io.StringReader;
-import java.io.StringWriter;
+import ro.pippo.core.Application;
+import ro.pippo.core.ContentTypeEngine;
+import ro.pippo.core.HttpConstants;
+import ro.pippo.core.PippoRuntimeException;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
+import java.io.StringReader;
+import java.io.StringWriter;
 
 /**
  * An XmlEngine based on JAXB.

--- a/pippo-jaxb/src/main/java/ro/pippo/jaxb/JaxbInitializer.java
+++ b/pippo-jaxb/src/main/java/ro/pippo/jaxb/JaxbInitializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.jaxb;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ro.pippo.core.Application;
+import ro.pippo.core.Initializer;
+
+/**
+ * @author James Moger
+ */
+public class JaxbInitializer implements Initializer {
+
+    private static final Logger log = LoggerFactory.getLogger(JaxbInitializer.class);
+
+    @Override
+    public void init(Application application) {
+        application.registerContentTypeEngine(JaxbEngine.class);
+    }
+
+    @Override
+    public void destroy(Application application) {
+    }
+
+}

--- a/pippo-jaxb/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
+++ b/pippo-jaxb/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
@@ -1,0 +1,1 @@
+ro.pippo.jaxb.JaxbEngine

--- a/pippo-jaxb/src/main/resources/pippo.properties
+++ b/pippo-jaxb/src/main/resources/pippo.properties
@@ -1,0 +1,1 @@
+initializer=ro.pippo.jaxb.JaxbInitializer

--- a/pom.xml
+++ b/pom.xml
@@ -163,10 +163,11 @@
         <module>pippo-trimou</module>
         <module>pippo-spring</module>
         <module>pippo-guice</module>
-		<module>pippo-weld</module>
+        <module>pippo-weld</module>
         <module>pippo-gson</module>
         <module>pippo-fastjson</module>
         <module>pippo-jackson</module>
+        <module>pippo-jaxb</module>
         <module>pippo-xstream</module>
         <module>pippo-snakeyaml</module>
         <module>pippo-metrics</module>


### PR DESCRIPTION
Unfortunately by having the JAXB engine set by the core it is not possible to replace it using our ServiceLoader/Initializer design.

We could add special cases to ContentTypeEngine registration - ick - or we could split the JAXB engine into a separate module that you must deliberately choose - I think this is better.