### PR TITLE
Allow specification of Accept-Type by appending a registered suffix to the request path

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/ContentTypeEngines.java
+++ b/pippo-core/src/main/java/ro/pippo/core/ContentTypeEngines.java
@@ -46,30 +46,20 @@ public class ContentTypeEngines {
     }
 
     /**
-     * Returns true if there is an engine registered for the content type.
+     * Returns true if there is an engine registered for the content type or content type suffix.
      *
-     * @param contentType
+     * @param contentTypeOrSuffix
      * @return true if there is an engine for the content type
      */
-    public boolean hasContentTypeEngine(String contentType) {
-        String sanitizedTypes = sanitizeContentTypes(contentType);
+    public boolean hasContentTypeEngine(String contentTypeOrSuffix) {
+        String sanitizedTypes = sanitizeContentTypes(contentTypeOrSuffix);
         String[] types = sanitizedTypes.split(",");
         for (String type : types) {
             if (engines.containsKey(type)) {
                 return true;
             }
         }
-        return false;
-    }
-
-    /**
-     * Returns true if there is an engine registered for the content type suffix.
-     *
-     * @param suffix
-     * @return true if there is an engine for the content type suffix
-     */
-    public boolean hasContentTypeSuffix(String suffix) {
-        return suffixes.containsKey(StringUtils.removeStart(suffix.toLowerCase(), "."));
+        return suffixes.containsKey(contentTypeOrSuffix.toLowerCase());
     }
 
     /**
@@ -130,18 +120,18 @@ public class ContentTypeEngines {
             return null;
         }
 
-        ContentTypeEngine engine = suffixes.get(contentTypeOrSuffix.toLowerCase());
-        if (engine != null) {
-            return engine;
-        }
-
         String sanitizedTypes = sanitizeContentTypes(contentTypeOrSuffix);
         String[] types = sanitizedTypes.split(",");
         for (String type : types) {
-            engine = engines.get(type);
+            ContentTypeEngine engine = engines.get(type);
             if (engine != null) {
                 return engine;
             }
+        }
+
+        ContentTypeEngine engine = suffixes.get(contentTypeOrSuffix.toLowerCase());
+        if (engine != null) {
+            return engine;
         }
 
         return null;

--- a/pippo-core/src/main/java/ro/pippo/core/Request.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Request.java
@@ -60,6 +60,7 @@ public final class Request {
     private String method;
     private String path;
 
+    private String acceptType;
     private String contentType;
     private String body; // cache
 
@@ -352,7 +353,18 @@ public final class Request {
     }
 
     public String getAcceptType() {
-        return httpServletRequest.getHeader(HttpConstants.Header.ACCEPT);
+        if (acceptType == null) {
+            acceptType = httpServletRequest.getHeader(HttpConstants.Header.ACCEPT);
+            // try to specify an AcceptType from an registered ContentType suffix
+            String suffix = StringUtils.getFileExtension(getPath());
+            if (!StringUtils.isNullOrEmpty(suffix)) {
+                ContentTypeEngine engine = contentTypeEngines.getContentTypeEngine(suffix);
+                if (engine != null) {
+                    acceptType = engine.getContentType();
+                }
+            }
+        }
+        return acceptType;
     }
 
     public String getContentType() {

--- a/pippo-core/src/main/java/ro/pippo/core/util/StringUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/StringUtils.java
@@ -198,4 +198,18 @@ public class StringUtils {
         return String.format(str, args);
     }
 
+    /**
+     * Returns the file extension of the value without the dot or an empty string.
+     *
+     * @param value
+     * @return the extension without dot or an empry string
+     */
+    public static String getFileExtension(String value) {
+        int index = value.lastIndexOf('.');
+        if (index > -1) {
+            return value.substring(index + 1);
+        }
+        return "";
+    }
+
 }

--- a/pippo-demo/pippo-demo-basic/pom.xml
+++ b/pippo-demo/pippo-demo-basic/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>pippo-fastjson</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>ro.pippo</groupId>
+            <artifactId>pippo-snakeyaml</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pippo-demo/pippo-demo-basic/src/main/java/ro/pippo/demo/basic/BasicApplication.java
+++ b/pippo-demo/pippo-demo-basic/src/main/java/ro/pippo/demo/basic/BasicApplication.java
@@ -115,7 +115,7 @@ public class BasicApplication extends Application {
         });
 
         // send an object and negotiate the Response content-type, default to XML
-        GET("/negotiate", new RouteHandler() {
+        GET("/negotiate(\\.(json|xml|yaml))?", new RouteHandler() {
 
             @Override
             public void handle(RouteContext routeContext) {
@@ -150,7 +150,7 @@ public class BasicApplication extends Application {
         });
 
         // send an error as response
-        GET("/error", new RouteHandler() {
+        GET("/error(\\.(json|xml|yaml))?", new RouteHandler() {
 
             @Override
             public void handle(RouteContext routeContext) {


### PR DESCRIPTION
This PR allows specification of the `Accept-Type` on the `Request` path.

    http://localhost:8338/contact
    http://localhost:8338/contact.json
    http://localhost:8338/contact.xml
    http://localhost:8338/contact.yaml

The path suffix is matched against the trailing pseudo-suffix of the registered `ContentTypeEngine`.

e.g. `application/json` = `json`
e.g. `application/x-yaml` = `yaml`

```java
GET("/contact(\\.(json|xml|yaml))?", new RouteHandler() {
    @Override
     public void handle(RouteContext routeContext) {
        Contact contact = new Contact()
            .setId(12345)
            .setName("John")
            .setPhone("0733434435")
            .setAddress("Sunflower Street, No. 6");
        routeContext.xml().negotiateContentType().send(contact);
    }
});
```

Aside from the verbose route path specification, the behavior is transparent to the end-user.  I have an idea on how to make this suffix support easier to use for route registration but it will require some rearchitecting to achieve.