### PR TITLE
Change Webjars path aliasing to only use the artifactId

### DIFF
--- a/pippo-demo/pippo-demo-crud/src/main/resources/templates/base.ftl
+++ b/pippo-demo/pippo-demo-crud/src/main/resources/templates/base.ftl
@@ -8,16 +8,16 @@
 
         <title>${title}</title>
 
-        <link href="${webjarsAt('bootstrap/current/css/bootstrap.min.css')}" rel="stylesheet">
-        <link href="${webjarsAt('font-awesome/current/css/font-awesome.min.css')}" rel="stylesheet">
+        <link href="${webjarsAt('bootstrap/css/bootstrap.min.css')}" rel="stylesheet">
+        <link href="${webjarsAt('font-awesome/css/font-awesome.min.css')}" rel="stylesheet">
         <link href="${publicAt('css/style.css')}" rel="stylesheet">
     </head>
     <body>
         <div class="container">
             <#nested/>
 
-            <script src="${webjarsAt('jquery/current/jquery.min.js')}"></script>
-            <script src="${webjarsAt('bootstrap/current/js/bootstrap.min.js')}"></script>
+            <script src="${webjarsAt('jquery/jquery.min.js')}"></script>
+            <script src="${webjarsAt('bootstrap/js/bootstrap.min.js')}"></script>
         </div>
     </body>
 </html>

--- a/pippo-demo/pippo-demo-crudng/src/main/resources/templates/base.ftl
+++ b/pippo-demo/pippo-demo-crudng/src/main/resources/templates/base.ftl
@@ -8,8 +8,8 @@
 
         <title>${title}</title>
 
-        <link href="${webjarsAt('bootstrap/current/css/bootstrap.min.css')}" rel="stylesheet">
-        <link href="${webjarsAt('font-awesome/current/css/font-awesome.min.css')}" rel="stylesheet">
+        <link href="${webjarsAt('bootstrap/css/bootstrap.min.css')}" rel="stylesheet">
+        <link href="${webjarsAt('font-awesome/css/font-awesome.min.css')}" rel="stylesheet">
         <link href="${publicAt('css/style.css')}" rel="stylesheet">
         <base href="${contextPath}/">
     </head>
@@ -17,9 +17,9 @@
         <div class="container">
             <#nested/>
 
-            <script src="${webjarsAt('jquery/current/jquery.min.js')}"></script>
-            <script src="${webjarsAt('bootstrap/current/js/bootstrap.min.js')}"></script>
-            <script src="${webjarsAt('angularjs/current/angular.min.js')}"></script>
+            <script src="${webjarsAt('jquery/1.11.1/jquery.min.js')}"></script>
+            <script src="${webjarsAt('bootstrap/js/bootstrap.min.js')}"></script>
+            <script src="${webjarsAt('angularjs/angular.min.js')}"></script>
             <script src="${publicAt('js/crudNgApp.js')}"></script>
         </div>
     </body>


### PR DESCRIPTION
This PR changes the Webjars handler version aliasing introduced in #180 to support implied request resource path version aliases like `jquery/` instead of requiring `jquery/current/` paths.

This means the first path segment (*artifactId*) will be substituted at runtime with *artifactId/version/* (e.g. `jquery/1.11.1/`) UNLESS the request resource path already starts with *artifactId/version/* (e.g. `jquery/1.11.1/`).