### PR TITLE
Fix alias substitution in webjars paths

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/route/WebjarsResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/WebjarsResourceHandler.java
@@ -66,7 +66,7 @@ public class WebjarsResourceHandler extends ClasspathResourceHandler {
             // i.e. skip replacing first path segment of "/jquery/1.11.1/jquery.min.js"
             // BUT do replace first path segment of "jquery/jquery.min.js".
             if (!resourcePath.startsWith(artifactVersion)) {
-                String aliasedPath = resourcePath.replace(artifactPath, artifactVersion);
+                String aliasedPath = artifactVersion + resourcePath.substring(artifactPath.length());
                 log.trace("Replaced Webjar path {} with {}", resourcePath, aliasedPath);
                 resourceName = getResourceBasePath() + "/" + aliasedPath;
             }


### PR DESCRIPTION
Found a nasty bug in the new webjars aliasing.

Example:
`${webjarsAt('foundation/js/foundation/foundation.alert.js')}`

will resolve to:
`/webjars/foundation/5.5.2/js/foundation/5.5.2/foundation.alert.js`

Note the double version substitution.  Iz bad.

This PR fixes that.  *I wouldn't be opposed to a quick 0.6.1.*

**Also.**
It should also be noted that our webjars aliasing may not work when the same version of a webjar is rebuilt with a `-n` suffix.

For example, font-awesome 4.3.0-1 is a rebuild of font-awesome 4.3.0 with an erroneous Maven dependency removed.  Inside the 4.3.0-1 jar the paths are still "4.3.0".  If we are brave we could strip the `-n` suffix but I honestly don't know if that will cause more harm than good.