### PR TITLE
Register Json, Xml, and Yaml engines with pippo-jackson

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/util/ClasspathUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/ClasspathUtils.java
@@ -84,4 +84,19 @@ public class ClasspathUtils {
         return list;
     }
 
+    /**
+     * Returns true if the specified class can be found on the classpath.
+     *
+     * @param className
+     * @return true if the class is on the classpath
+     */
+    public static boolean hasClass(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (Exception e) {
+        }
+        return false;
+    }
+
 }

--- a/pippo-demo/pippo-demo-basic/pom.xml
+++ b/pippo-demo/pippo-demo-basic/pom.xml
@@ -35,15 +35,10 @@
 
         <dependency>
             <groupId>ro.pippo</groupId>
-            <artifactId>pippo-fastjson</artifactId>
+            <artifactId>pippo-jackson</artifactId>
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>ro.pippo</groupId>
-            <artifactId>pippo-snakeyaml</artifactId>
-            <version>${project.version}</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/pippo-jackson/pom.xml
+++ b/pippo-jackson/pom.xml
@@ -32,6 +32,16 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
             <version>${jackson.version}</version>

--- a/pippo-jackson/pom.xml
+++ b/pippo-jackson/pom.xml
@@ -35,11 +35,13 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
             <version>${jackson.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>

--- a/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonBaseEngine.java
+++ b/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonBaseEngine.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (C) 2014 the original author or authors.
+ * Copyright (C) 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file eTcept in compliance with the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either eTpress or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
@@ -30,33 +30,30 @@ import java.io.IOException;
 import java.util.TimeZone;
 
 /**
- * A JsonEngine based on Jackson.
+ * Base class for ContentTypeEngines based on Jackson.
  *
  * @author James Moger
  */
-public class JacksonEngine implements ContentTypeEngine {
+public abstract class JacksonBaseEngine implements ContentTypeEngine {
 
     protected ObjectMapper objectMapper;
 
     @Override
     public void init(Application application) {
-        objectMapper = new ObjectMapper();
+        objectMapper = getObjectMapper();
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         objectMapper.setTimeZone(TimeZone.getDefault());
         objectMapper.registerModule(new AfterburnerModule());
     }
 
-    @Override
-    public String getContentType() {
-        return HttpConstants.ContentType.APPLICATION_JSON;
-    }
+    protected abstract ObjectMapper getObjectMapper();
 
     @Override
     public String toString(Object object) {
         try {
             return objectMapper.writeValueAsString(object);
         } catch (JsonProcessingException e) {
-            throw new PippoRuntimeException("Error serializing object to JSON", e);
+            throw new PippoRuntimeException("Error serializing object to {}", e, getContentType());
         }
     }
 
@@ -65,9 +62,9 @@ public class JacksonEngine implements ContentTypeEngine {
         try {
             return objectMapper.readValue(content, classOfT);
         } catch (JsonParseException | JsonMappingException ex) {
-            throw new PippoRuntimeException("Error deserializing JSON", ex);
+            throw new PippoRuntimeException("Error deserializing {}", ex, getContentType());
         } catch (IOException e) {
-            throw new PippoRuntimeException("Invalid Json document", e);
+            throw new PippoRuntimeException("Invalid {} document", e, getContentType());
         }
     }
 

--- a/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonInitializer.java
+++ b/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonInitializer.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.Application;
 import ro.pippo.core.Initializer;
+import ro.pippo.core.util.ClasspathUtils;
 
 /**
  * @author James Moger
@@ -30,8 +31,12 @@ public class JacksonInitializer implements Initializer {
     @Override
     public void init(Application application) {
         application.registerContentTypeEngine(JacksonJsonEngine.class);
-        application.registerContentTypeEngine(JacksonXmlEngine.class);
-        application.registerContentTypeEngine(JacksonYamlEngine.class);
+        if (ClasspathUtils.hasClass("com.fasterxml.jackson.dataformat.xml.XmlMapper")) {
+            application.registerContentTypeEngine(JacksonXmlEngine.class);
+        }
+        if (ClasspathUtils.hasClass("com.fasterxml.jackson.dataformat.yaml.YAMLMapper")) {
+            application.registerContentTypeEngine(JacksonYamlEngine.class);
+        }
     }
 
     @Override

--- a/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonJsonEngine.java
+++ b/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonJsonEngine.java
@@ -15,27 +15,24 @@
  */
 package ro.pippo.jackson;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import ro.pippo.core.Application;
-import ro.pippo.core.Initializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ro.pippo.core.HttpConstants;
 
 /**
+ * A JSON ContentTypeEngine based on Jackson.
+ *
  * @author James Moger
  */
-public class JacksonInitializer implements Initializer {
-
-    private static final Logger log = LoggerFactory.getLogger(JacksonInitializer.class);
+public class JacksonJsonEngine extends JacksonBaseEngine {
 
     @Override
-    public void init(Application application) {
-        application.registerContentTypeEngine(JacksonJsonEngine.class);
-        application.registerContentTypeEngine(JacksonXmlEngine.class);
-        application.registerContentTypeEngine(JacksonYamlEngine.class);
+    protected ObjectMapper getObjectMapper() {
+        return new ObjectMapper();
     }
 
     @Override
-    public void destroy(Application application) {
+    public String getContentType() {
+        return HttpConstants.ContentType.APPLICATION_JSON;
     }
 
 }

--- a/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonXmlEngine.java
+++ b/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonXmlEngine.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import ro.pippo.core.HttpConstants;
+
+/**
+ * An XML ContentTypeEngine based on Jackson.
+ *
+ * @author James Moger
+ */
+public class JacksonXmlEngine extends JacksonBaseEngine {
+
+    @Override
+    protected ObjectMapper getObjectMapper() {
+        // Check out: https://github.com/FasterXML/jackson-dataformat-xml
+        JacksonXmlModule module = new JacksonXmlModule();
+        // setDefaultUseWrapper produces more similar output to
+        // the Json output. You can change that with annotations in your
+        // models.
+        module.setDefaultUseWrapper(false);
+        return new XmlMapper(module);
+    }
+
+    @Override
+    public String getContentType() {
+        return HttpConstants.ContentType.APPLICATION_XML;
+    }
+
+}

--- a/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonYamlEngine.java
+++ b/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonYamlEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 the original author or authors.
+ * Copyright (C) 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,27 +15,26 @@
  */
 package ro.pippo.jackson;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import ro.pippo.core.Application;
-import ro.pippo.core.Initializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import ro.pippo.core.HttpConstants;
 
 /**
+ * An YAML ContentTypeEngine based on Jackson.
+ *
  * @author James Moger
  */
-public class JacksonInitializer implements Initializer {
-
-    private static final Logger log = LoggerFactory.getLogger(JacksonInitializer.class);
+public class JacksonYamlEngine extends JacksonBaseEngine {
 
     @Override
-    public void init(Application application) {
-        application.registerContentTypeEngine(JacksonJsonEngine.class);
-        application.registerContentTypeEngine(JacksonXmlEngine.class);
-        application.registerContentTypeEngine(JacksonYamlEngine.class);
+    protected ObjectMapper getObjectMapper() {
+        return new YAMLMapper();
     }
 
     @Override
-    public void destroy(Application application) {
+    public String getContentType() {
+        return HttpConstants.ContentType.APPLICATION_X_YAML;
     }
 
 }
+

--- a/pippo-jackson/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
+++ b/pippo-jackson/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
@@ -1,1 +1,3 @@
-ro.pippo.jackson.JacksonEngine
+ro.pippo.jackson.JacksonJsonEngine
+ro.pippo.jackson.JacksonXmlEngine
+ro.pippo.jackson.JacksonYamlEngine

--- a/pippo-jackson/src/test/java/ro/pippo/jackson/JacksonBaseEngineTest.java
+++ b/pippo-jackson/src/test/java/ro/pippo/jackson/JacksonBaseEngineTest.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (C) 2014 the original author or authors.
+ * Copyright (C) 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file eTcept in compliance with the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either eTpress or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
@@ -24,18 +24,20 @@ import java.util.Date;
 /**
  * @author James Moger
  */
-public class JacksonEngineTest extends Assert {
+public abstract class JacksonBaseEngineTest extends Assert {
+
+    protected abstract JacksonBaseEngine getEngine();
 
     @Test
     public void testEngine() {
         MyTest test = new MyTest();
 
-        JacksonEngine engine = new JacksonEngine();
+        JacksonBaseEngine engine = getEngine();
         engine.init(null);
 
-        String json = engine.toString(test);
+        String aString = engine.toString(test);
 
-        MyTest result = engine.fromString(json, MyTest.class);
+        MyTest result = engine.fromString(aString, MyTest.class);
         assertEquals(test.message, result.message);
     }
 
@@ -48,12 +50,12 @@ public class JacksonEngineTest extends Assert {
         MyTest test = new MyTest();
         test.date = now;
 
-        JacksonEngine engine = new JacksonEngine();
+        JacksonBaseEngine engine = getEngine();
         engine.init(null);
 
-        String json = engine.toString(test);
+        String aString = engine.toString(test);
 
-        MyTest result = engine.fromString(json, MyTest.class);
+        MyTest result = engine.fromString(aString, MyTest.class);
         assertEquals(test.message, result.message);
 
         assertTrue(test.date.equals(result.date));

--- a/pippo-jackson/src/test/java/ro/pippo/jackson/JacksonJsonEngineTest.java
+++ b/pippo-jackson/src/test/java/ro/pippo/jackson/JacksonJsonEngineTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.jackson;
+
+/**
+ * @author James Moger
+ */
+public class JacksonJsonEngineTest extends JacksonBaseEngineTest {
+
+    @Override
+    protected JacksonBaseEngine getEngine() {
+        return new JacksonJsonEngine();
+    }
+}

--- a/pippo-jackson/src/test/java/ro/pippo/jackson/JacksonXmlEngineTest.java
+++ b/pippo-jackson/src/test/java/ro/pippo/jackson/JacksonXmlEngineTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.jackson;
+
+/**
+ * @author James Moger
+ */
+public class JacksonXmlEngineTest extends JacksonBaseEngineTest {
+
+    @Override
+    protected JacksonBaseEngine getEngine() {
+        return new JacksonXmlEngine();
+    }
+}

--- a/pippo-jackson/src/test/java/ro/pippo/jackson/JacksonYamlEngineTest.java
+++ b/pippo-jackson/src/test/java/ro/pippo/jackson/JacksonYamlEngineTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.jackson;
+
+/**
+ * @author James Moger
+ */
+public class JacksonYamlEngineTest extends JacksonBaseEngineTest {
+
+    @Override
+    protected JacksonBaseEngine getEngine() {
+        return new JacksonYamlEngine();
+    }
+}


### PR DESCRIPTION
Jackson supports reading/writing multiple formats using the same set of annotations.  In many cases you may not need any data annotations at all to read/write.

This PR refactors the Jackson integration to register Json, Xml, and Yaml engines.  It's a one-stop dependency for all three content types.

What do you think of this approach?