### PR TITLE
ParameterValue.toXXX() returns Object instead of primitive got numeric, boolean, chart

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java
+++ b/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java
@@ -50,106 +50,106 @@ public class ParameterValue implements Serializable {
         this.values = values;
     }
 
-    public boolean toBoolean() {
-        return toBoolean(false);
+    public Boolean toBoolean() {
+        return toBoolean(null);
     }
 
-    public boolean toBoolean(boolean defaultValue) {
-        if (isNull()) {
+    public Boolean toBoolean(Boolean defaultValue) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
+
         switch (values[0]) {
             case "yes":
             case "on":
                 return true;
             default:
-                return Boolean.parseBoolean(values[0]);
+                return Boolean.valueOf(values[0]);
         }
     }
 
-    public byte toByte() {
-        return toByte((byte) 0);
+    public Byte toByte() {
+        return toByte(null);
     }
 
-    public byte toByte(byte defaultValue) {
-        if (isNull()) {
+    public Byte toByte(Byte defaultValue) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
-        return Byte.parseByte(values[0]);
+        return Byte.valueOf(values[0]);
     }
 
-    public short toShort() {
-        return toShort((short) 0);
+    public Short toShort() {
+        return toShort(null);
     }
 
-    public short toShort(short defaultValue) {
-        if (isNull()) {
+    public Short toShort(Short defaultValue) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
-        return Short.parseShort(values[0]);
+        return Short.valueOf(values[0]);
     }
 
-    public int toInt() {
-        return toInt(0);
+    public Integer toInt() {
+        return toInt(null);
     }
 
-    public int toInt(int defaultValue) {
-        if (isNull()) {
+    public Integer toInt(Integer defaultValue) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
-        return Integer.parseInt(values[0]);
+        return Integer.valueOf(values[0]);
     }
 
-    public long toLong() {
-        return toLong(0);
+    public Long toLong() {
+        return toLong(null);
     }
 
-    public long toLong(long defaultValue) {
-        if (isNull()) {
+    public Long toLong(Long defaultValue) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
-        return Long.parseLong(values[0]);
+        return Long.valueOf(values[0]);
     }
 
-    public float toFloat() {
-        return toFloat(0);
+    public Float toFloat() {
+        return toFloat(null);
     }
 
-    public float toFloat(float defaultValue) {
-        if (isNull()) {
+    public Float toFloat(Float defaultValue) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
-        return Float.parseFloat(values[0]);
+        return Float.valueOf(values[0]);
     }
 
-    public double toDouble() {
-        return toDouble(0);
+    public Double toDouble() {
+        return toDouble(null);
     }
 
-    public double toDouble(double defaultValue) {
-        if (isNull()) {
+    public Double toDouble(Double defaultValue) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
-        return Double.parseDouble(values[0]);
+        return Double.valueOf(values[0]);
     }
 
     public BigDecimal toBigDecimal() {
-        return toBigDecimal(BigDecimal.ZERO);
+        return toBigDecimal(null);
     }
 
     public BigDecimal toBigDecimal(BigDecimal defaultValue) {
-        if (isNull()) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
-        double d = Double.parseDouble(values[0]);
-        return new BigDecimal(d);
+        return new BigDecimal(Double.parseDouble(values[0]));
     }
 
     public UUID toUUID() {
@@ -157,7 +157,7 @@ public class ParameterValue implements Serializable {
     }
 
     public UUID toUUID(UUID defaultValue) {
-        if (isNull()) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
@@ -165,11 +165,11 @@ public class ParameterValue implements Serializable {
     }
 
     public Character toCharacter() {
-        return toCharacter((char) 0);
+        return toCharacter(null);
     }
 
     public Character toCharacter(Character defaultValue) {
-        if (isNull()) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
@@ -182,7 +182,7 @@ public class ParameterValue implements Serializable {
     }
 
     public String toString(String defaultValue) {
-        if (isNull()) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
@@ -198,7 +198,7 @@ public class ParameterValue implements Serializable {
     }
 
     public <T extends Enum<?>> T toEnum(Class<T> classOfT, T defaultValue, boolean caseSensitive) {
-        if (isNull()) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
@@ -207,6 +207,7 @@ public class ParameterValue implements Serializable {
             // attempt to interpret value as an ordinal
             ordinal = Integer.parseInt(values[0]);
         } catch (Exception e) {
+            // ignore
         }
 
         T[] constants = classOfT.getEnumConstants();
@@ -214,6 +215,7 @@ public class ParameterValue implements Serializable {
             if (constant.ordinal() == ordinal) {
                 return constant;
             }
+
             if (caseSensitive) {
                 if (constant.name().equals(values[0])) {
                     return constant;
@@ -224,6 +226,7 @@ public class ParameterValue implements Serializable {
                 }
             }
         }
+
         return defaultValue;
     }
 
@@ -232,14 +235,15 @@ public class ParameterValue implements Serializable {
     }
 
     public Set<String> toSet(Set<String> defaultValue) {
-        if (isNull()) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
         if (values.length == 1) {
-            return new HashSet<String>(Arrays.asList(values[0].split(",")));
+            return new HashSet<>(Arrays.asList(values[0].split(",")));
         }
-        return new HashSet<String>(Arrays.asList(values));
+
+        return new HashSet<>(Arrays.asList(values));
     }
 
     /**
@@ -270,7 +274,7 @@ public class ParameterValue implements Serializable {
     }
 
     public List<String> toList(List<String> defaultValue) {
-        if (isNull()) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
@@ -298,14 +302,12 @@ public class ParameterValue implements Serializable {
     }
 
     public Date toDate(Date defaultValue, String pattern) {
-        if (isNull()) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat(pattern);
         try {
-            Date date = dateFormat.parse(values[0]);
-            return date;
+            return new SimpleDateFormat(pattern).parse(values[0]);
         } catch (ParseException e) {
             throw new PippoRuntimeException(e);
         }
@@ -316,12 +318,11 @@ public class ParameterValue implements Serializable {
     }
 
     public java.sql.Date toSqlDate(java.sql.Date defaultValue) {
-        if (isNull()) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
-        java.sql.Date date = java.sql.Date.valueOf(values[0]);
-        return date;
+        return java.sql.Date.valueOf(values[0]);
     }
 
     public Time toSqlTime() {
@@ -329,12 +330,11 @@ public class ParameterValue implements Serializable {
     }
 
     public Time toSqlTime(Time defaultValue) {
-        if (isNull()) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
-        Time time = Time.valueOf(values[0]);
-        return time;
+        return Time.valueOf(values[0]);
     }
 
     public Timestamp toSqlTimestamp() {
@@ -342,12 +342,11 @@ public class ParameterValue implements Serializable {
     }
 
     public Timestamp toSqlTimestamp(Timestamp defaultValue) {
-        if (isNull()) {
+        if (isNullOrEmpty()) {
             return defaultValue;
         }
 
-        Timestamp timestamp = Timestamp.valueOf(values[0]);
-        return timestamp;
+        return Timestamp.valueOf(values[0]);
     }
 
     public <T> T to(Class<T> classOfT) {
@@ -373,7 +372,7 @@ public class ParameterValue implements Serializable {
             Class<?> componentType = classOfT.getComponentType();
             Object array;
             // cheat by not instantiating a ParameterValue for every value
-            ParameterValue parameterValue = new ParameterValue(new String[]{"PLACEHOLDER"});
+            ParameterValue parameterValue = new ParameterValue("PLACEHOLDER");
             if (values.length == 1) {
                 // split a single-value list into an array
                 String tmp = values[0];
@@ -424,7 +423,7 @@ public class ParameterValue implements Serializable {
             X collection = (X) constructor.newInstance();
 
             // cheat by not instantiating a ParameterValue for every value
-            ParameterValue parameterValue = new ParameterValue(new String[]{"PLACEHOLDER"});
+            ParameterValue parameterValue = new ParameterValue("PLACEHOLDER");
 
             List<String> list;
             if (values.length == 1) {
@@ -447,6 +446,7 @@ public class ParameterValue implements Serializable {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private Object toObject(Class<?> type, String pattern) {
         if (type == String.class) {
             return toString();
@@ -493,8 +493,7 @@ public class ParameterValue implements Serializable {
         }
 
         if (type.isEnum()) {
-            Class<? extends Enum> enumClass = (Class<? extends Enum>) type;
-            return toEnum(enumClass);
+            return toEnum((Class<? extends Enum>) type);
         }
 
         if (pattern == null) {
@@ -534,6 +533,10 @@ public class ParameterValue implements Serializable {
 
     public boolean isEmpty() {
         return values == null || values.length == 0 || StringUtils.isNullOrEmpty(values[0]);
+    }
+
+    public boolean isNullOrEmpty() {
+        return isNull() || isEmpty();
     }
 
     public boolean isMultiValued() {

--- a/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
@@ -62,29 +62,29 @@ public class ParameterValueTest extends Assert {
 
     @Test
     public void testBytes() throws Exception {
-        assertEquals(127, new ParameterValue("127").toByte());
-        assertEquals(127, new ParameterValue("127", "96", "64").toByte());
+        assertEquals(127, new ParameterValue("127").toByte().byteValue());
+        assertEquals(127, new ParameterValue("127", "96", "64").toByte().byteValue());
         assertArrayEquals(new byte[]{127, 96, 64}, new ParameterValue("127", "96", "64").to(byte[].class));
     }
 
     @Test
     public void testShorts() throws Exception {
-        assertEquals(4096, new ParameterValue("4096").toShort());
-        assertEquals(4096, new ParameterValue("4096", "2048", "1024").toShort());
+        assertEquals(4096, new ParameterValue("4096").toShort().shortValue());
+        assertEquals(4096, new ParameterValue("4096", "2048", "1024").toShort().shortValue());
         assertArrayEquals(new short[]{4096, 2048, 1024}, new ParameterValue(new String[]{"4096", "2048", "1024"}).to(short[].class));
     }
 
     @Test
     public void testIntegers() throws Exception {
-        assertEquals(131070, new ParameterValue("131070").toInt());
-        assertEquals(131070, new ParameterValue("131070", "65535", "32767").toInt());
+        assertEquals(131070, new ParameterValue("131070").toInt().intValue());
+        assertEquals(131070, new ParameterValue("131070", "65535", "32767").toInt().intValue());
         assertArrayEquals(new int[]{131070, 65535, 32767}, new ParameterValue("131070", "65535", "32767").to(int[].class));
     }
 
     @Test
     public void testLongs() throws Exception {
-        assertEquals(8589934588L, new ParameterValue("8589934588").toLong());
-        assertEquals(8589934588L, new ParameterValue("8589934588", "4294967294", "2147483647").toLong());
+        assertEquals(8589934588L, new ParameterValue("8589934588").toLong().longValue());
+        assertEquals(8589934588L, new ParameterValue("8589934588", "4294967294", "2147483647").toLong().longValue());
         assertArrayEquals(new long[]{8589934588L, 4294967294L, 2147483647L}, new ParameterValue("8589934588", "4294967294", "2147483647").to(long[].class));
     }
 
@@ -272,6 +272,35 @@ public class ParameterValueTest extends Assert {
         assertEquals(Alphabet.A, new ParameterValue("0").toEnum(Alphabet.class, null, false));
         assertEquals(Alphabet.D, new ParameterValue("3").toEnum(Alphabet.class, null, false));
 
+    }
+
+    @Test
+    public void testNull() {
+        // null value
+        ParameterValue parameterValue = new ParameterValue();
+
+        assertNull(parameterValue.toBoolean());
+        assertNull(parameterValue.toCharacter());
+        assertNull(parameterValue.toByte());
+        assertNull(parameterValue.toShort());
+        assertNull(parameterValue.toInt());
+        assertNull(parameterValue.toLong());
+        assertNull(parameterValue.toFloat());
+        assertNull(parameterValue.toDouble());
+        assertNull(parameterValue.toBigDecimal());
+
+        // empty value
+        parameterValue = new ParameterValue("");
+
+        assertNull(parameterValue.toBoolean());
+        assertNull(parameterValue.toCharacter());
+        assertNull(parameterValue.toByte());
+        assertNull(parameterValue.toShort());
+        assertNull(parameterValue.toInt());
+        assertNull(parameterValue.toLong());
+        assertNull(parameterValue.toFloat());
+        assertNull(parameterValue.toDouble());
+        assertNull(parameterValue.toBigDecimal());
     }
 
     public static enum Alphabet {


### PR DESCRIPTION
My goal is to simplify the parameter value read process for null or empty values.

Before this PR:
```java
// the correct approach for test null or empty value 
ParameterValue idParam = routeContext.getParameter("id");
if (idParam.isNull() || idParam.isEmpty()) {
    // no id parameter
} else {
    long id = idParam.toLong();   
    // do my job
}

// the short version
```java
long id = routeContext.getParameter("id").toLong();
if (id > 0) {
    // do my job
}
```

The problems with last snippet are:
- I cannot know if the request parameter is null or is 0 (or other default value)
- I am in trouble if the request parameter is empty (I am encountered some situations) because a "NumberFormatException" is thrown; this situation can be avoided if we change `isNull()` from check `if (isNull()) { return defaultValue; }` with a more comprehensive `isNullOrEmpty()`

With current PR we can write:
```java
Long id = routeContext.getParameter("id").toLong();
// id is null if the parameter value is null or empty
if (id != null) {
    // do my job
}
```

For my tests this PR does't not affect existing applications built with Pippo.

What do you think, brings value or not this PR?