### PR TITLE
remove "extends Assert" from each existent Test class

### DIFF
--- a/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
@@ -16,7 +16,6 @@
 package ro.pippo.core;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,11 +30,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.*;
 
 /**
  * @author Decebal Suiu
  */
-public class DefaultRouterTest extends Assert {
+public class DefaultRouterTest {
 
     private DefaultRouter router;
 

--- a/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
@@ -16,7 +16,6 @@
 package ro.pippo.core;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,10 +33,12 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 
+import static org.junit.Assert.*;
+
 /**
  * @author James Moger
  */
-public class ParameterValueTest extends Assert {
+public class ParameterValueTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();

--- a/pippo-core/src/test/java/ro/pippo/core/PathRegexBuilderTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/PathRegexBuilderTest.java
@@ -15,17 +15,18 @@
  */
 package ro.pippo.core;
 
-import org.junit.Assert;
 import org.junit.Test;
 import ro.pippo.core.util.PathRegexBuilder;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.junit.Assert.*;
+
 /**
  * @author Decebal Suiu
  */
-public class PathRegexBuilderTest extends Assert {
+public class PathRegexBuilderTest {
 
     @Test
     public void testBuild() throws Exception {


### PR DESCRIPTION
I don't like the idea of static import in general but I think that we must do a concession for the test classes.
In pippo test classes we extended Assert class only to force the import but I think that it's bad for readability.

I used InteliiJ Idea so I used [this](http://stackoverflow.com/questions/5107023/add-favorite-methods-to-static-import-in-intellij) recommendation in my projects.
