### PR TITLE
make TemplateEngine configurable (see #211)

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/TemplateEngine.java
+++ b/pippo-core/src/main/java/ro/pippo/core/TemplateEngine.java
@@ -21,7 +21,7 @@ import java.util.Map;
 /**
  * @author Decebal Suiu
  */
-public interface TemplateEngine {
+public interface TemplateEngine<T> {
 
     public final static String DEFAULT_PATH_PREFIX = "/templates";
 
@@ -43,5 +43,7 @@ public interface TemplateEngine {
     public void renderString(String templateContent, Map<String, Object> model, Writer writer);
 
     public void renderResource(String templateName, Map<String, Object> model, Writer writer);
+
+    public T getEngine();
 
 }

--- a/pippo-freemarker/src/main/java/ro/pippo/freemarker/FreemarkerTemplateEngine.java
+++ b/pippo-freemarker/src/main/java/ro/pippo/freemarker/FreemarkerTemplateEngine.java
@@ -36,7 +36,7 @@ import freemarker.template.Template;
 /**
  * @author Decebal Suiu
  */
-public class FreemarkerTemplateEngine implements TemplateEngine {
+public class FreemarkerTemplateEngine implements TemplateEngine<Configuration> {
 
     public static final String FTL = "ftl";
     public static final String FILE_SUFFIX = "." + FTL;
@@ -100,10 +100,6 @@ public class FreemarkerTemplateEngine implements TemplateEngine {
         publicResourcesMethod = new PublicAtMethod(router);
     }
 
-    public Configuration getConfiguration() {
-        return configuration;
-    }
-
     @Override
     public void renderString(String templateContent, Map<String, Object> model, Writer writer) {
         // prepare the locale-aware i18n method
@@ -159,6 +155,11 @@ public class FreemarkerTemplateEngine implements TemplateEngine {
         } catch (Exception e) {
             throw new PippoRuntimeException(e);
         }
+    }
+
+    @Override
+    public Configuration getEngine() {
+        return configuration;
     }
 
 }

--- a/pippo-groovy/src/main/java/ro/pippo/groovy/GroovyTemplateEngine.java
+++ b/pippo-groovy/src/main/java/ro/pippo/groovy/GroovyTemplateEngine.java
@@ -41,7 +41,7 @@ import ro.pippo.core.util.StringUtils;
  *
  * @author James Moger
  */
-public class GroovyTemplateEngine implements TemplateEngine {
+public class GroovyTemplateEngine implements TemplateEngine<MarkupTemplateEngine> {
 
     private static final Logger log = LoggerFactory.getLogger(GroovyTemplateEngine.class);
 
@@ -123,6 +123,11 @@ public class GroovyTemplateEngine implements TemplateEngine {
             log.error("Error processing Groovy template {} ", templateName, e);
             throw new PippoRuntimeException(e);
         }
+    }
+
+    @Override
+    public MarkupTemplateEngine getEngine() {
+        return engine;
     }
 
 }

--- a/pippo-jade/src/main/java/ro/pippo/jade/JadeTemplateEngine.java
+++ b/pippo-jade/src/main/java/ro/pippo/jade/JadeTemplateEngine.java
@@ -15,15 +15,11 @@
  */
 package ro.pippo.jade;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.Writer;
-import java.util.Locale;
-import java.util.Map;
-
+import de.neuland.jade4j.Jade4J.Mode;
+import de.neuland.jade4j.JadeConfiguration;
+import de.neuland.jade4j.template.JadeTemplate;
 import de.neuland.jade4j.template.ReaderTemplateLoader;
+import de.neuland.jade4j.template.TemplateLoader;
 import ro.pippo.core.Application;
 import ro.pippo.core.Languages;
 import ro.pippo.core.Messages;
@@ -33,15 +29,19 @@ import ro.pippo.core.PippoSettings;
 import ro.pippo.core.TemplateEngine;
 import ro.pippo.core.route.Router;
 import ro.pippo.core.util.StringUtils;
-import de.neuland.jade4j.Jade4J.Mode;
-import de.neuland.jade4j.JadeConfiguration;
-import de.neuland.jade4j.template.JadeTemplate;
-import de.neuland.jade4j.template.TemplateLoader;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.Writer;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * @author Decebal Suiu
  */
-public class JadeTemplateEngine implements TemplateEngine {
+public class JadeTemplateEngine implements TemplateEngine<JadeConfiguration> {
 
     private Languages languages;
     private Messages messages;
@@ -71,10 +71,6 @@ public class JadeTemplateEngine implements TemplateEngine {
         // set global template variables
         configuration.getSharedVariables().put("contextPath", router.getContextPath());
         configuration.getSharedVariables().put("appPath", router.getApplicationPath());
-    }
-
-    public JadeConfiguration getConfiguration() {
-        return configuration;
     }
 
     @Override
@@ -131,6 +127,11 @@ public class JadeTemplateEngine implements TemplateEngine {
         } catch (Exception e) {
             throw new PippoRuntimeException(e);
         }
+    }
+
+    @Override
+    public JadeConfiguration getEngine() {
+        return configuration;
     }
 
     private static class ClassTemplateLoader implements TemplateLoader {

--- a/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
+++ b/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
@@ -48,7 +48,7 @@ import com.mitchellbosecke.pebble.template.PebbleTemplate;
  *
  * @author James Moger
  */
-public class PebbleTemplateEngine implements TemplateEngine {
+public class PebbleTemplateEngine implements TemplateEngine<PebbleEngine> {
 
     private final Logger log = LoggerFactory.getLogger(PebbleTemplateEngine.class);
 
@@ -154,6 +154,11 @@ public class PebbleTemplateEngine implements TemplateEngine {
         } catch (Exception e) {
             throw new PippoRuntimeException(e);
         }
+    }
+
+    @Override
+    public PebbleEngine getEngine() {
+        return engine;
     }
 
     private PebbleTemplate getTemplate(String templateName, String localePart) throws PebbleException {

--- a/pippo-trimou/src/main/java/ro/pippo/trimou/TrimouTemplateEngine.java
+++ b/pippo-trimou/src/main/java/ro/pippo/trimou/TrimouTemplateEngine.java
@@ -43,7 +43,7 @@ import java.util.Map;
  *
  * @author James Moger
  */
-public class TrimouTemplateEngine implements TemplateEngine {
+public class TrimouTemplateEngine implements TemplateEngine<MustacheEngine> {
 
     private static final Logger log = LoggerFactory.getLogger(TrimouTemplateEngine.class);
 
@@ -171,6 +171,11 @@ public class TrimouTemplateEngine implements TemplateEngine {
         } finally {
             localeSupport.remove();
         }
+    }
+
+    @Override
+    public MustacheEngine getEngine() {
+        return engine;
     }
 
     private String getLocalizedTemplateName(String templateName, String localePart) {

--- a/pippo-velocity/src/main/java/ro/pippo/velocity/VelocityTemplateEngine.java
+++ b/pippo-velocity/src/main/java/ro/pippo/velocity/VelocityTemplateEngine.java
@@ -40,7 +40,7 @@ import java.util.Properties;
 /**
  * @author Decebal Suiu
  */
-public class VelocityTemplateEngine implements TemplateEngine {
+public class VelocityTemplateEngine implements TemplateEngine<VelocityEngine> {
 
     public static final String VM = "vm";
     public static final String FILE_SUFFIX = "." + VM;
@@ -48,7 +48,7 @@ public class VelocityTemplateEngine implements TemplateEngine {
     private Languages languages;
     private Messages messages;
     private Router router;
-    private VelocityEngine velocityEngine;
+    private VelocityEngine engine;
 
     @Override
     public void init(Application application) {
@@ -87,11 +87,7 @@ public class VelocityTemplateEngine implements TemplateEngine {
 //        properties.setProperty("input.encoding","UTF-8");
 //        properties.setProperty("output.encoding","UTF-8");
 
-        velocityEngine = new VelocityEngine(properties);
-    }
-
-    public VelocityEngine getVelocityEngine() {
-        return velocityEngine;
+        engine = new VelocityEngine(properties);
     }
 
     @Override
@@ -126,11 +122,16 @@ public class VelocityTemplateEngine implements TemplateEngine {
 
         // merge the template
         try {
-            Template template = velocityEngine.getTemplate(templateName);
+            Template template = engine.getTemplate(templateName);
             template.merge(context, writer);
         } catch (Exception e) {
             throw new PippoRuntimeException(e);
         }
+    }
+
+    @Override
+    public VelocityEngine getEngine() {
+        return engine;
     }
 
     private VelocityContext createVelocityContext(Map<String, Object> model) {


### PR DESCRIPTION
A proof of concept. See #211 for more information.

Conclusion:
- __Groovy__, we export `MarkupTemplateEngine` but my feeling is that we cannot modify some configuration parameters using this object
- __Jade__, we export `JadeConfiguration`, not the engine
- __Pebble__, we export `PebbleEngine`, perfect
- __Trimou__, we export `MustacheEngine` but all settings are done in a previous [step](https://github.com/decebals/pippo/blob/master/pippo-trimou/src/main/java/ro/pippo/trimou/TrimouTemplateEngine.java#L65) in `MustacheEngineBuilder`, my feeling is that we cannot modify some configuration parameters using this object (MustacheEngine)
- __Freemarker__, we export `Configuration`, not the engine
- __Velocity__, we export `Velocity` engine but  all settings are done in a previous [step](https://github.com/decebals/pippo/blob/master/pippo-velocity/src/main/java/ro/pippo/velocity/VelocityTemplateEngine.java#L68)

So, I don't have a perfect fit. I will try to dig more. Any idea is welcome.