### PR TITLE
make TemplateEngine configurable (see #211), reloaded

### DIFF
--- a/pippo-freemarker/src/main/java/ro/pippo/freemarker/FreemarkerTemplateEngine.java
+++ b/pippo-freemarker/src/main/java/ro/pippo/freemarker/FreemarkerTemplateEngine.java
@@ -98,10 +98,9 @@ public class FreemarkerTemplateEngine implements TemplateEngine {
 
         webjarResourcesMethod = new WebjarsAtMethod(router);
         publicResourcesMethod = new PublicAtMethod(router);
-    }
 
-    public Configuration getConfiguration() {
-        return configuration;
+        // allow custom initialization
+        init(configuration);
     }
 
     @Override
@@ -159,6 +158,9 @@ public class FreemarkerTemplateEngine implements TemplateEngine {
         } catch (Exception e) {
             throw new PippoRuntimeException(e);
         }
+    }
+
+    protected void init(Configuration configuration) {
     }
 
 }

--- a/pippo-groovy/src/main/java/ro/pippo/groovy/GroovyTemplateEngine.java
+++ b/pippo-groovy/src/main/java/ro/pippo/groovy/GroovyTemplateEngine.java
@@ -85,6 +85,10 @@ public class GroovyTemplateEngine implements TemplateEngine {
         GroovyTemplateResolver cachingResolver = new GroovyTemplateResolver(pathPrefix);
 
         ClassLoader classLoader = getClass().getClassLoader();
+
+        // allow custom initialization
+        init(configuration);
+
         engine = new MarkupTemplateEngine(classLoader, configuration, cachingResolver);
     }
 
@@ -123,6 +127,9 @@ public class GroovyTemplateEngine implements TemplateEngine {
             log.error("Error processing Groovy template {} ", templateName, e);
             throw new PippoRuntimeException(e);
         }
+    }
+
+    protected void init(TemplateConfiguration configuration) {
     }
 
 }

--- a/pippo-jade/src/main/java/ro/pippo/jade/JadeTemplateEngine.java
+++ b/pippo-jade/src/main/java/ro/pippo/jade/JadeTemplateEngine.java
@@ -71,10 +71,9 @@ public class JadeTemplateEngine implements TemplateEngine {
         // set global template variables
         configuration.getSharedVariables().put("contextPath", router.getContextPath());
         configuration.getSharedVariables().put("appPath", router.getApplicationPath());
-    }
 
-    public JadeConfiguration getConfiguration() {
-        return configuration;
+        // allow custom initialization
+        init(configuration);
     }
 
     @Override
@@ -131,6 +130,9 @@ public class JadeTemplateEngine implements TemplateEngine {
         } catch (Exception e) {
             throw new PippoRuntimeException(e);
         }
+    }
+
+    protected void init(JadeConfiguration configuration) {
     }
 
     private static class ClassTemplateLoader implements TemplateLoader {

--- a/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
+++ b/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
@@ -96,6 +96,9 @@ public class PebbleTemplateEngine implements TemplateEngine {
         // set global template variables
         engine.getGlobalVariables().put("contextPath", router.getContextPath());
         engine.getGlobalVariables().put("appPath", router.getApplicationPath());
+
+        // allow custom initialization
+        init(engine);
     }
 
     @Override
@@ -154,6 +157,9 @@ public class PebbleTemplateEngine implements TemplateEngine {
         } catch (Exception e) {
             throw new PippoRuntimeException(e);
         }
+    }
+
+    protected void init(PebbleEngine engine) {
     }
 
     private PebbleTemplate getTemplate(String templateName, String localePart) throws PebbleException {

--- a/pippo-trimou/src/main/java/ro/pippo/trimou/TrimouTemplateEngine.java
+++ b/pippo-trimou/src/main/java/ro/pippo/trimou/TrimouTemplateEngine.java
@@ -92,6 +92,9 @@ public class TrimouTemplateEngine implements TemplateEngine {
         builder.addGlobalData("contextPath", router.getContextPath());
         builder.addGlobalData("appPath", router.getApplicationPath());
 
+        // allow custom initialization
+        init(builder);
+
         engine = builder.build();
     }
 
@@ -171,6 +174,9 @@ public class TrimouTemplateEngine implements TemplateEngine {
         } finally {
             localeSupport.remove();
         }
+    }
+
+    protected void init(MustacheEngineBuilder builder) {
     }
 
     private String getLocalizedTemplateName(String templateName, String localePart) {

--- a/pippo-velocity/src/main/java/ro/pippo/velocity/VelocityTemplateEngine.java
+++ b/pippo-velocity/src/main/java/ro/pippo/velocity/VelocityTemplateEngine.java
@@ -87,11 +87,10 @@ public class VelocityTemplateEngine implements TemplateEngine {
 //        properties.setProperty("input.encoding","UTF-8");
 //        properties.setProperty("output.encoding","UTF-8");
 
-        velocityEngine = new VelocityEngine(properties);
-    }
+        // allow custom initialization
+        init(properties);
 
-    public VelocityEngine getVelocityEngine() {
-        return velocityEngine;
+        velocityEngine = new VelocityEngine(properties);
     }
 
     @Override
@@ -131,6 +130,9 @@ public class VelocityTemplateEngine implements TemplateEngine {
         } catch (Exception e) {
             throw new PippoRuntimeException(e);
         }
+    }
+
+    protected void init(Properties properties) {
     }
 
     private VelocityContext createVelocityContext(Map<String, Object> model) {


### PR DESCRIPTION
Implementation based on [this](https://github.com/decebals/pippo/pull/212#issuecomment-136359578) comment.

I have a updated pippo-demo-template on pipe:
```java
public class PebbleDemo {

    public static void main(String[] args) {
        // .peb is the default file extension
//        Pippo pippo = new Pippo(new TemplateApplication(new PebbleTemplateEngine(), "pebble/hello"));
        Pippo pippo = new Pippo(new TemplateApplication(new MyPebbleTemplateEngine(), "pebble/hello"));
        pippo.start();
    }

    public static class MyPebbleTemplateEngine extends PebbleTemplateEngine {

        @Override
        protected void init(PebbleEngine engine) {
            engine.addExtension(new AbstractExtension() {

                @Override
                public Map<String, Filter> getFilters() {
                    Map<String, Filter> filters = new HashMap<>();
                    filters.put("myupper", new MyUpperFilter());

                    return filters;
                }

            });
        }

    }

    public static class MyUpperFilter implements Filter {

        @Override
        public List<String> getArgumentNames() {
            return null;
        }

        @Override
        public Object apply(Object input, Map<String, Object> args){
            return (input != null) ? ((String) input).toUpperCase() : null;
        }

    }

}
```