### PR TITLE
Fix CSRF guard failure on content-types with specified charsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### [Unreleased][unreleased]
 #### Fixed
+- [#215]: Fixed CSRF guard ignoring POST requests with content-types that specify a charset
 #### Changed
 - Updated [pippo-pebble] to Pebble 1.5.2
 - Updated [pippo-metrics-librato] to Librato 4.0.1.11
@@ -168,6 +169,7 @@ Initial release.
 [0.3.0]: https://github.com/decebals/pippo/compare/pippo-parent-0.2.0...pippo-parent-0.3.0
 [0.2.0]: https://github.com/decebals/pippo/compare/pippo-parent-0.1.0...pippo-parent-0.2.0
 
+[#215]: https://github.com/decebals/pippo/issues/215
 [#185]: https://github.com/decebals/pippo/issues/185
 [#184]: https://github.com/decebals/pippo/issues/184
 [#183]: https://github.com/decebals/pippo/issues/183

--- a/pippo-core/src/main/java/ro/pippo/core/route/CSRFHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/CSRFHandler.java
@@ -110,6 +110,7 @@ public class CSRFHandler implements RouteHandler<RouteContext> {
 
             // Verify the content-type is guarded
             String contentType = new ParameterValue(context.getHeader("Content-Type")).toString("").toLowerCase();
+            contentType = StringUtils.getPrefix(contentType, ';').trim();
             if (!guardedTypes.contains(contentType)) {
                 log.debug("Ignoring '{}' request for {} '{}'", contentType, context.getRequestMethod(),
                     context.getRequestUri());

--- a/pippo-core/src/main/java/ro/pippo/core/util/StringUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/StringUtils.java
@@ -212,4 +212,19 @@ public class StringUtils {
         return "";
     }
 
+    /**
+     * Returns the prefix of the input string from 0 to the first index of the delimiter OR it returns the input string.
+     *
+     * @param input
+     * @param delimiter
+     * @return the prefix substring or the entire input string if the delimiter is not found
+     */
+    public static String getPrefix(String input, char delimiter) {
+        int index = input.indexOf(delimiter);
+        if (index > -1) {
+            return input.substring(0, index);
+        }
+        return input;
+    }
+
 }


### PR DESCRIPTION
The CSRF guard skips token validation for POST requests that are sent with charsets.
e.g. `Content-Type: application/x-www-form-urlencoded; charset=utf8`.

This is no bueno.  :-1: