### PR TITLE
Add method to finalize the Response and return the raw output stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated [pippo-undertow] to Undertow 1.2.12
 - Updated [pippo-trimou] to Trimou 1.8.2
 #### Added
+- [#217]: Add Response method to finalize a response and return the OutputStream for custom streaming
 #### Removed
 
 ### [0.6.0] - 2015-06-03
@@ -169,6 +170,7 @@ Initial release.
 [0.3.0]: https://github.com/decebals/pippo/compare/pippo-parent-0.2.0...pippo-parent-0.3.0
 [0.2.0]: https://github.com/decebals/pippo/compare/pippo-parent-0.1.0...pippo-parent-0.2.0
 
+[#217]: https://github.com/decebals/pippo/issues/217
 [#215]: https://github.com/decebals/pippo/issues/215
 [#185]: https://github.com/decebals/pippo/issues/185
 [#184]: https://github.com/decebals/pippo/issues/184

--- a/pippo-core/src/main/java/ro/pippo/core/Response.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Response.java
@@ -30,6 +30,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -1039,6 +1040,22 @@ public final class Response {
         }
 
         return finalizeListeners;
+    }
+
+    public OutputStream getOutputStream() {
+        checkCommitted();
+        finalizeResponse();
+
+        // content type to OCTET_STREAM if it's not set
+        if (getContentType() == null) {
+            contentType(HttpConstants.ContentType.APPLICATION_OCTET_STREAM);
+        }
+
+        try {
+            return httpServletResponse.getOutputStream();
+        } catch (IOException e) {
+            throw new PippoRuntimeException(e);
+        }
     }
 
     public static Response get() {


### PR DESCRIPTION
Pippo is an abstraction and convenience layer for the servlet API.  If you
need to implement custom streaming you can not use any of the Response
API when setting up headers, etc.  This change allows you to configure the
Response, as you normally would, and then obtain the raw output stream for
custom response streaming.