### PR TITLE
Allow use of UTF-8 in path parameter expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Added
 - [#217]: Add convenience methods for setting date headers
 - [#218]: Add Response method to finalize a response and return the OutputStream for custom streaming
+- [#220]: Add support for `:alnum:`, `:alpha:`, `:ascii:`, `:digit:`, `:xdigit:` POSIX character classes for URL path parameters. This allows use of UTF-8 in path parameters.
 #### Removed
 
 ### [0.6.0] - 2015-06-03
@@ -174,6 +175,7 @@ Initial release.
 [0.3.0]: https://github.com/decebals/pippo/compare/pippo-parent-0.2.0...pippo-parent-0.3.0
 [0.2.0]: https://github.com/decebals/pippo/compare/pippo-parent-0.1.0...pippo-parent-0.2.0
 
+[#220]: https://github.com/decebals/pippo/issues/220
 [#218]: https://github.com/decebals/pippo/issues/218
 [#217]: https://github.com/decebals/pippo/issues/217
 [#215]: https://github.com/decebals/pippo/issues/215

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -332,7 +332,8 @@ public class DefaultRouter implements Router {
 
             if (namedVariablePartOfRoute != null) {
                 // we convert that into a regex matcher group itself
-                namedVariablePartOfORouteReplacedWithRegex = "(" + Matcher.quoteReplacement(namedVariablePartOfRoute) + ")";
+                String variableRegex = replacePosixClasses(namedVariablePartOfRoute);
+                namedVariablePartOfORouteReplacedWithRegex = "(" + Matcher.quoteReplacement(variableRegex) + ")";
             } else {
                 // we convert that into the default namedVariablePartOfRoute regex group
                 namedVariablePartOfORouteReplacedWithRegex = VARIABLE_ROUTES_DEFAULT_REGEX;
@@ -345,6 +346,21 @@ public class DefaultRouter implements Router {
         matcher.appendTail(buffer);
 
         return buffer.toString();
+    }
+
+    /**
+     * Replace any specified POSIX character classes with the Java equivalent.
+     *
+     * @param input
+     * @return a Java regex
+     */
+    private String replacePosixClasses(String input) {
+        return input
+            .replace(":alnum:", "\\p{Alnum}")
+            .replace(":alpha:", "\\p{L}")
+            .replace(":ascii:", "\\p{ASCII}")
+            .replace(":digit:", "\\p{Digit}")
+            .replace(":xdigit:", "\\p{XDigit}");
     }
 
     /**

--- a/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
@@ -191,6 +191,112 @@ public class DefaultRouterTest {
     }
 
     @Test
+    public void testPosixAlpha() throws Exception {
+        Route route = new Route("/user/{login: :alpha:+}/todo/{id: :digit:+}", HttpConstants.Method.GET,
+            new EmptyRouteHandler());
+        router.addRoute(route);
+
+        List<RouteMatch> routeMatches = router.findRoutes("/user/jämяs/todo/57", HttpConstants.Method.GET);
+        assertEquals(1, routeMatches.size());
+
+        Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
+        assertNotNull(pathParameters);
+        assertEquals(2, pathParameters.size());
+        assertTrue(pathParameters.containsKey("login"));
+        assertEquals("jämяs", pathParameters.get("login"));
+        assertTrue(pathParameters.containsKey("id"));
+        assertEquals("57", pathParameters.get("id"));
+    }
+
+    @Test
+    public void testPosixAlpha2() throws Exception {
+        Route route = new Route("/user/{login: [:digit::alpha:-_\\+\\.]+}/todo/{id: :digit:+}", HttpConstants.Method.GET,
+            new EmptyRouteHandler());
+        router.addRoute(route);
+
+        List<RouteMatch> routeMatches = router.findRoutes("/user/j.ä_я3-s/todo/57", HttpConstants.Method.GET);
+        assertEquals(1, routeMatches.size());
+
+        Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
+        assertNotNull(pathParameters);
+        assertEquals(2, pathParameters.size());
+        assertTrue(pathParameters.containsKey("login"));
+        assertEquals("j.ä_я3-s", pathParameters.get("login"));
+        assertTrue(pathParameters.containsKey("id"));
+        assertEquals("57", pathParameters.get("id"));
+    }
+
+    @Test
+    public void testPosixAlnum() throws Exception {
+        Route route = new Route("/user/{login: :alnum:+}", HttpConstants.Method.GET,
+            new EmptyRouteHandler());
+        router.addRoute(route);
+
+        List<RouteMatch> routeMatches = router.findRoutes("/user/james5", HttpConstants.Method.GET);
+        assertEquals(1, routeMatches.size());
+
+        Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
+        assertNotNull(pathParameters);
+        assertEquals(1, pathParameters.size());
+        assertTrue(pathParameters.containsKey("login"));
+        assertEquals("james5", pathParameters.get("login"));
+    }
+
+    @Test
+    public void testPosixDigit() throws Exception {
+        Route route = new Route("/contact/{id: :digit:+}/{field: :alpha:+}", HttpConstants.Method.GET,
+            new EmptyRouteHandler());
+        router.addRoute(route);
+
+        List<RouteMatch> routeMatches = router.findRoutes("/contact/57/telephone", HttpConstants.Method.GET);
+        assertEquals(1, routeMatches.size());
+
+        Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
+        assertNotNull(pathParameters);
+        assertEquals(2, pathParameters.size());
+        assertTrue(pathParameters.containsKey("id"));
+        assertEquals("57", pathParameters.get("id"));
+        assertTrue(pathParameters.containsKey("field"));
+        assertEquals("telephone", pathParameters.get("field"));
+    }
+
+    @Test
+    public void testPosixHexDigit() throws Exception {
+        Route route = new Route("/contact/{id: :xdigit:+}/{field: :digit:+}", HttpConstants.Method.GET,
+            new EmptyRouteHandler());
+        router.addRoute(route);
+
+        List<RouteMatch> routeMatches = router.findRoutes("/contact/5ace076/97", HttpConstants.Method.GET);
+        assertEquals(1, routeMatches.size());
+
+        Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
+        assertNotNull(pathParameters);
+        assertEquals(2, pathParameters.size());
+        assertTrue(pathParameters.containsKey("id"));
+        assertEquals("5ace076", pathParameters.get("id"));
+        assertTrue(pathParameters.containsKey("field"));
+        assertEquals("97", pathParameters.get("field"));
+    }
+
+    @Test
+    public void testPosixASCII() throws Exception {
+        Route route = new Route("/contact/{id: :ascii:+}/{field: :digit:+}", HttpConstants.Method.GET,
+            new EmptyRouteHandler());
+        router.addRoute(route);
+
+        List<RouteMatch> routeMatches = router.findRoutes("/contact/5ace076/97", HttpConstants.Method.GET);
+        assertEquals(1, routeMatches.size());
+
+        Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
+        assertNotNull(pathParameters);
+        assertEquals(2, pathParameters.size());
+        assertTrue(pathParameters.containsKey("id"));
+        assertEquals("5ace076", pathParameters.get("id"));
+        assertTrue(pathParameters.containsKey("field"));
+        assertEquals("97", pathParameters.get("field"));
+    }
+
+    @Test
     public void testWebjarsRoute() throws Exception {
         WebjarsResourceHandler webjars = new WebjarsResourceHandler();
         Route route = new Route(webjars.getUriPattern(), HttpConstants.Method.GET, new EmptyRouteHandler());


### PR DESCRIPTION
Add support for the `:alnum:`, `:alpha:`, `:ascii:`, `:digit:`, and `:xdigit:` POSIX character classes in URL path parameters.  These values are substituted for their Java equivalent when the Route PatternBinding is created by DefaultRouter.

Using the Java equivalent syntax *directly* creates complications with the existing route parameter matching expression due to nesting of curly braces.  This alternative is less invasive.