### PR TITLE
use standard java service loader mechanism via ServiceLocator and remove pippo.properties files

### DIFF
--- a/pippo-fastjson/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-fastjson/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,0 +1,1 @@
+ro.pippo.fastjson.FastjsonInitializer

--- a/pippo-fastjson/src/main/resources/pippo.properties
+++ b/pippo-fastjson/src/main/resources/pippo.properties
@@ -1,1 +1,0 @@
-initializer=ro.pippo.fastjson.FastjsonInitializer

--- a/pippo-freemarker/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-freemarker/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,0 +1,1 @@
+ro.pippo.freemarker.FreemarkerInitializer

--- a/pippo-freemarker/src/main/resources/pippo.properties
+++ b/pippo-freemarker/src/main/resources/pippo.properties
@@ -1,1 +1,0 @@
-initializer=ro.pippo.freemarker.FreemarkerInitializer

--- a/pippo-groovy/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-groovy/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,0 +1,1 @@
+ro.pippo.groovy.GroovyInitializer

--- a/pippo-groovy/src/main/resources/pippo.properties
+++ b/pippo-groovy/src/main/resources/pippo.properties
@@ -1,1 +1,0 @@
-initializer=ro.pippo.groovy.GroovyInitializer

--- a/pippo-gson/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-gson/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,0 +1,1 @@
+ro.pippo.gson.GsonInitializer

--- a/pippo-gson/src/main/resources/pippo.properties
+++ b/pippo-gson/src/main/resources/pippo.properties
@@ -1,1 +1,0 @@
-initializer=ro.pippo.gson.GsonInitializer

--- a/pippo-jackson/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-jackson/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,0 +1,1 @@
+ro.pippo.jackson.JacksonInitializer

--- a/pippo-jackson/src/main/resources/pippo.properties
+++ b/pippo-jackson/src/main/resources/pippo.properties
@@ -1,1 +1,0 @@
-initializer=ro.pippo.jackson.JacksonInitializer

--- a/pippo-jade/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-jade/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,0 +1,1 @@
+ro.pippo.jade.JadeInitializer

--- a/pippo-jade/src/main/resources/pippo.properties
+++ b/pippo-jade/src/main/resources/pippo.properties
@@ -1,1 +1,0 @@
-initializer=ro.pippo.jade.JadeInitializer

--- a/pippo-jaxb/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-jaxb/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,0 +1,1 @@
+ro.pippo.jaxb.JaxbInitializer

--- a/pippo-jaxb/src/main/resources/pippo.properties
+++ b/pippo-jaxb/src/main/resources/pippo.properties
@@ -1,1 +1,0 @@
-initializer=ro.pippo.jaxb.JaxbInitializer

--- a/pippo-pebble/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-pebble/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,0 +1,1 @@
+ro.pippo.pebble.PebbleInitializer

--- a/pippo-pebble/src/main/resources/pippo.properties
+++ b/pippo-pebble/src/main/resources/pippo.properties
@@ -1,1 +1,0 @@
-initializer=ro.pippo.pebble.PebbleInitializer

--- a/pippo-snakeyaml/src/main/resources/pippo.properties
+++ b/pippo-snakeyaml/src/main/resources/pippo.properties
@@ -1,1 +1,0 @@
-initializer=ro.pippo.snakeyaml.SnakeYamlInitializer

--- a/pippo-snakeyaml/src/main/resources/services/ro.pippo.core.Initializer
+++ b/pippo-snakeyaml/src/main/resources/services/ro.pippo.core.Initializer
@@ -1,0 +1,1 @@
+ro.pippo.snakeyaml.SnakeYamlInitializer

--- a/pippo-trimou/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-trimou/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,0 +1,1 @@
+ro.pippo.trimou.TrimouInitializer

--- a/pippo-trimou/src/main/resources/pippo.properties
+++ b/pippo-trimou/src/main/resources/pippo.properties
@@ -1,1 +1,0 @@
-initializer=ro.pippo.trimou.TrimouInitializer

--- a/pippo-velocity/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-velocity/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,0 +1,1 @@
+ro.pippo.velocity.VelocityInitializer

--- a/pippo-velocity/src/main/resources/pippo.properties
+++ b/pippo-velocity/src/main/resources/pippo.properties
@@ -1,1 +1,0 @@
-initializer=ro.pippo.velocity.VelocityInitializer

--- a/pippo-xstream/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-xstream/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,0 +1,1 @@
+ro.pippo.xstream.XstreamInitializer

--- a/pippo-xstream/src/main/resources/pippo.properties
+++ b/pippo-xstream/src/main/resources/pippo.properties
@@ -1,1 +1,0 @@
-initializer=ro.pippo.xstream.XstreamInitializer


### PR DESCRIPTION
The idea is to simplify the `Initializer` implementation and to use an unitary services/extensions mechanism in Pippo (we already use java `ServiceLoader` mechanism via `ServiceLocator` for `ContentTypeEngine`, `TemplateEngine`).