### PR TITLE
Cosmetics for Route class

### DIFF
--- a/pippo-controller/src/main/java/ro/pippo/controller/ControllerApplication.java
+++ b/pippo-controller/src/main/java/ro/pippo/controller/ControllerApplication.java
@@ -18,7 +18,6 @@ package ro.pippo.controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.Application;
-import ro.pippo.core.HttpConstants;
 import ro.pippo.core.PippoRuntimeException;
 import ro.pippo.core.PippoSettings;
 import ro.pippo.core.route.Route;
@@ -49,38 +48,31 @@ public class ControllerApplication extends Application {
     }
 
     public Route GET(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        return addRoute(uriPattern, HttpConstants.Method.GET, controllerClass, methodName);
+        return GET(uriPattern, createRouteHandler(controllerClass, methodName));
     }
 
     public Route POST(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        return addRoute(uriPattern, HttpConstants.Method.POST, controllerClass, methodName);
+        return POST(uriPattern, createRouteHandler(controllerClass, methodName));
     }
 
     public Route DELETE(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        return addRoute(uriPattern, HttpConstants.Method.DELETE, controllerClass, methodName);
+        return DELETE(uriPattern, createRouteHandler(controllerClass, methodName));
     }
 
     public Route HEAD(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        return addRoute(uriPattern, HttpConstants.Method.HEAD, controllerClass, methodName);
+        return HEAD(uriPattern, createRouteHandler(controllerClass, methodName));
     }
 
     public Route PUT(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        return addRoute(uriPattern, HttpConstants.Method.PUT, controllerClass, methodName);
+        return PUT(uriPattern, createRouteHandler(controllerClass, methodName));
     }
 
     public Route PATCH(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        return addRoute(uriPattern, HttpConstants.Method.PATCH, controllerClass, methodName);
+        return PATCH(uriPattern, createRouteHandler(controllerClass, methodName));
     }
 
     public Route ALL(String uriPattern, Class<? extends Controller> controllerClass, String methodName) {
-        return addRoute(uriPattern, HttpConstants.Method.ALL, controllerClass, methodName);
-    }
-
-    public Route addRoute(String uriPattern, String requestMethod, Class<? extends Controller> controllerClass, String methodName) {
-        RouteHandler routeHandler = getControllerHandlerFactory().createHandler(controllerClass, methodName);
-        Route route = addRoute(uriPattern, requestMethod, routeHandler);
-
-        return route;
+        return ALL(uriPattern, createRouteHandler(controllerClass, methodName));
     }
 
     public ControllerHandlerFactory getControllerHandlerFactory() {
@@ -149,6 +141,10 @@ public class ControllerApplication extends Application {
     public void setControllerFactory(ControllerFactory controllerFactory) {
         this.controllerFactory = controllerFactory;
         log.debug("Controller factory is '{}'", controllerFactory.getClass().getName());
+    }
+
+    public RouteHandler createRouteHandler(Class<? extends Controller> controllerClass, String methodName) {
+        return getControllerHandlerFactory().createHandler(controllerClass, methodName);
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/Application.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Application.java
@@ -243,8 +243,8 @@ public class Application {
         return addRoute(uriPattern, HttpConstants.Method.ALL, routeHandler);
     }
 
-    public Route addRoute(String uriPattern, String requestMethod, RouteHandler routeHandler) {
-        Route route = new Route(uriPattern, requestMethod, routeHandler);
+    public Route addRoute(String requestMethod, String uriPattern, RouteHandler routeHandler) {
+        Route route = new Route(requestMethod, uriPattern, routeHandler);
         getRouter().addRoute(route);
 
         return route;

--- a/pippo-core/src/main/java/ro/pippo/core/Application.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Application.java
@@ -216,38 +216,56 @@ public class Application {
             throw new PippoRuntimeException("Please use 'addResourceRoute()'");
         }
 
-        return addRoute(uriPattern, HttpConstants.Method.GET, routeHandler);
+        Route route = Route.GET(uriPattern, routeHandler);
+        addRoute(route);
+
+        return route;
     }
 
     public Route POST(String uriPattern, RouteHandler routeHandler) {
-        return addRoute(uriPattern, HttpConstants.Method.POST, routeHandler);
+        Route route = Route.POST(uriPattern, routeHandler);
+        addRoute(route);
+
+        return route;
     }
 
     public Route DELETE(String uriPattern, RouteHandler routeHandler) {
-        return addRoute(uriPattern, HttpConstants.Method.DELETE, routeHandler);
+        Route route = Route.DELETE(uriPattern, routeHandler);
+        addRoute(route);
+
+        return route;
     }
 
     public Route HEAD(String uriPattern, RouteHandler routeHandler) {
-        return addRoute(uriPattern, HttpConstants.Method.HEAD, routeHandler);
+        Route route = Route.HEAD(uriPattern, routeHandler);
+        addRoute(route);
+
+        return route;
     }
 
     public Route PUT(String uriPattern, RouteHandler routeHandler) {
-        return addRoute(uriPattern, HttpConstants.Method.PUT, routeHandler);
+        Route route = Route.PUT(uriPattern, routeHandler);
+        addRoute(route);
+
+        return route;
     }
 
     public Route PATCH(String uriPattern, RouteHandler routeHandler) {
-        return addRoute(uriPattern, HttpConstants.Method.PATCH, routeHandler);
+        Route route = Route.PATCH(uriPattern, routeHandler);
+        addRoute(route);
+
+        return route;
     }
 
     public Route ALL(String uriPattern, RouteHandler routeHandler) {
-        return addRoute(uriPattern, HttpConstants.Method.ALL, routeHandler);
-    }
-
-    public Route addRoute(String requestMethod, String uriPattern, RouteHandler routeHandler) {
-        Route route = new Route(requestMethod, uriPattern, routeHandler);
-        getRouter().addRoute(route);
+        Route route = Route.ALL(uriPattern, routeHandler);
+        addRoute(route);
 
         return route;
+    }
+
+    public void addRoute(Route route) {
+        getRouter().addRoute(route);
     }
 
     /**
@@ -301,7 +319,10 @@ public class Application {
     }
 
     public Route addResourceRoute(ResourceHandler resourceHandler) {
-        return addRoute(resourceHandler.getUriPattern(), HttpConstants.Method.GET, resourceHandler);
+        Route route = Route.GET(resourceHandler.getUriPattern(), resourceHandler);
+        addRoute(route);
+
+        return route;
     }
 
     public ErrorHandler getErrorHandler() {

--- a/pippo-core/src/main/java/ro/pippo/core/Application.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Application.java
@@ -85,7 +85,7 @@ public class Application {
     }
 
     public final void init() {
-        initializers.addAll(getInitializers());
+        initializers.addAll(ServiceLocator.locateAll(Initializer.class));
         for (Initializer initializer : initializers) {
             log.debug("Initializing '{}'", initializer.getClass().getName());
             try {
@@ -408,10 +408,6 @@ public class Application {
         RouteContext routeContext = RouteDispatcher.getRouteContext();
 
         return (routeContext != null) ? routeContext.getApplication() : null;
-    }
-
-    private List<Initializer> getInitializers() {
-        return ServiceLocator.locateAll(Initializer.class);
     }
 
     @Override

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -142,7 +142,7 @@ public class DefaultRouter implements Router {
     }
 
     @Override
-    public List<RouteMatch> findRoutes(String requestUri, String requestMethod) {
+    public List<RouteMatch> findRoutes(String requestMethod, String requestUri) {
         log.trace("Finding route matches for {} '{}'", requestMethod, requestUri);
 
         List<RouteMatch> routeMatches = new ArrayList<>();

--- a/pippo-core/src/main/java/ro/pippo/core/route/Route.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Route.java
@@ -20,24 +20,25 @@ package ro.pippo.core.route;
  */
 public class Route {
 
-    private String uriPattern;
     private String requestMethod;
+    private String uriPattern;
     private RouteHandler routeHandler;
+
     private boolean runAsFinally;
     private String name;
 
-    public Route(String uriPattern, String requestMethod, RouteHandler routeHandler) {
-        this.uriPattern = uriPattern;
+    public Route(String requestMethod, String uriPattern, RouteHandler routeHandler) {
         this.requestMethod = requestMethod;
+        this.uriPattern = uriPattern;
         this.routeHandler = routeHandler;
-    }
-
-    public String getUriPattern() {
-        return uriPattern;
     }
 
     public String getRequestMethod() {
         return requestMethod;
+    }
+
+    public String getUriPattern() {
+        return uriPattern;
     }
 
     public RouteHandler getRouteHandler() {

--- a/pippo-core/src/main/java/ro/pippo/core/route/Route.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Route.java
@@ -15,6 +15,8 @@
  */
 package ro.pippo.core.route;
 
+import ro.pippo.core.HttpConstants;
+
 /**
  * @author Decebal Suiu
  */
@@ -31,6 +33,83 @@ public class Route {
         this.requestMethod = requestMethod;
         this.uriPattern = uriPattern;
         this.routeHandler = routeHandler;
+    }
+
+    /**
+     * Create a GET route.
+     *
+     * @param uriPattern
+     * @param routeHandler
+     * @return
+     */
+    public static Route GET(String uriPattern, RouteHandler routeHandler) {
+        return new Route(HttpConstants.Method.GET, uriPattern, routeHandler);
+    }
+
+    /**
+     * Create a POST route.
+     *
+     * @param uriPattern
+     * @param routeHandler
+     * @return
+     */
+    public static Route POST(String uriPattern, RouteHandler routeHandler) {
+        return new Route(HttpConstants.Method.POST, uriPattern, routeHandler);
+    }
+
+    /**
+     * Create a DELETE route.
+     *
+     * @param uriPattern
+     * @param routeHandler
+     * @return
+     */
+    public static Route DELETE(String uriPattern, RouteHandler routeHandler) {
+        return new Route(HttpConstants.Method.DELETE, uriPattern, routeHandler);
+    }
+
+    /**
+     * Create a HEAD route.
+     *
+     * @param uriPattern
+     * @param routeHandler
+     * @return
+     */
+    public static Route HEAD(String uriPattern, RouteHandler routeHandler) {
+        return new Route(HttpConstants.Method.HEAD, uriPattern, routeHandler);
+    }
+
+    /**
+     * Create a PUT route.
+     *
+     * @param uriPattern
+     * @param routeHandler
+     * @return
+     */
+    public static Route PUT(String uriPattern, RouteHandler routeHandler) {
+        return new Route(HttpConstants.Method.PUT, uriPattern, routeHandler);
+    }
+
+    /**
+     * Create a PATCH route.
+     *
+     * @param uriPattern
+     * @param routeHandler
+     * @return
+     */
+    public static Route PATCH(String uriPattern, RouteHandler routeHandler) {
+        return new Route(HttpConstants.Method.PATCH, uriPattern, routeHandler);
+    }
+
+    /**
+     * Create a ALL route.
+     *
+     * @param uriPattern
+     * @param routeHandler
+     * @return
+     */
+    public static Route ALL(String uriPattern, RouteHandler routeHandler) {
+        return new Route(HttpConstants.Method.ALL, uriPattern, routeHandler);
     }
 
     public String getRequestMethod() {

--- a/pippo-core/src/main/java/ro/pippo/core/route/RouteDispatcher.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/RouteDispatcher.java
@@ -131,7 +131,7 @@ public class RouteDispatcher {
             return;
         }
 
-        List<RouteMatch> routeMatches = router.findRoutes(requestPath, requestMethod);
+        List<RouteMatch> routeMatches = router.findRoutes(requestMethod, requestPath);
         RouteContext routeContext = routeContextFactory.createRouteContext(application, request, response, routeMatches);
         ROUTE_CONTEXT_THREAD_LOCAL.set(routeContext);
 

--- a/pippo-core/src/main/java/ro/pippo/core/route/Router.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Router.java
@@ -50,7 +50,7 @@ public interface Router {
 
     public void removeRoute(Route route);
 
-    public List<RouteMatch> findRoutes(String requestUri, String requestMethod);
+    public List<RouteMatch> findRoutes(String requestMethod, String requestUri);
 
     public List<Route> getRoutes();
 

--- a/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
@@ -54,7 +54,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testNullUriPatternRoute() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, null, new EmptyRouteHandler());
+        Route route = Route.GET(null, new EmptyRouteHandler());
         thrown.expect(Exception.class);
         thrown.expectMessage("The uri pattern cannot be null or empty");
         router.addRoute(route);
@@ -62,7 +62,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testEmptyUriPatternRoute() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "", new EmptyRouteHandler());
+        Route route = Route.GET("", new EmptyRouteHandler());
         thrown.expect(Exception.class);
         thrown.expectMessage("The uri pattern cannot be null or empty");
         router.addRoute(route);
@@ -78,7 +78,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testAddRoute() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/.*", new EmptyRouteHandler());
+        Route route = Route.GET("/.*", new EmptyRouteHandler());
         router.addRoute(route);
 
         assertEquals(1, router.getRoutes().size());
@@ -87,7 +87,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testRemoveRoute() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/.*", new EmptyRouteHandler());
+        Route route = Route.GET("/.*", new EmptyRouteHandler());
         router.addRoute(route);
 
         assertEquals(1, router.getRoutes().size());
@@ -100,7 +100,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testFindRoutes() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/contact", new EmptyRouteHandler());
+        Route route = Route.GET("/contact", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact");
@@ -118,7 +118,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPathParamsRoute() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/contact/{id}", new EmptyRouteHandler());
+        Route route = Route.GET("/contact/{id}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact/3");
@@ -133,7 +133,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testWildcardRoute() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/.*", new EmptyRouteHandler());
+        Route route = Route.GET("/.*", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact/3");
@@ -142,7 +142,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPatchRoute() throws Exception {
-        Route route = new Route(HttpConstants.Method.PATCH, "/contact/{id}", new EmptyRouteHandler());
+        Route route = Route.PATCH("/contact/{id}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.PATCH, "/contact/3");
@@ -157,7 +157,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testIntIdRoute() throws Exception {
-        Route route = new Route(HttpConstants.Method.PATCH, "/contact/{id: [0-9]+}", new EmptyRouteHandler());
+        Route route = Route.PATCH("/contact/{id: [0-9]+}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.PATCH, "/contact/3");
@@ -175,8 +175,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testIntIdRoute2() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/contact/{id: [0-9]+}/something/{else: [A-z]*}",
-            new EmptyRouteHandler());
+        Route route = Route.GET("/contact/{id: [0-9]+}/something/{else: [A-z]*}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact/3/something/borrowed");
@@ -192,8 +191,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPosixAlpha() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/user/{login: :alpha:+}/todo/{id: :digit:+}",
-            new EmptyRouteHandler());
+        Route route = Route.GET("/user/{login: :alpha:+}/todo/{id: :digit:+}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/user/jämяs/todo/57");
@@ -210,8 +208,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPosixAlpha2() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/user/{login: [:digit::alpha:-_\\+\\.]+}/todo/{id: :digit:+}",
-            new EmptyRouteHandler());
+        Route route = Route.GET("/user/{login: [:digit::alpha:-_\\+\\.]+}/todo/{id: :digit:+}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/user/j.ä_я3-s/todo/57");
@@ -228,8 +225,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPosixAlnum() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/user/{login: :alnum:+}",
-            new EmptyRouteHandler());
+        Route route = Route.GET("/user/{login: :alnum:+}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/user/james5");
@@ -244,8 +240,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPosixDigit() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/contact/{id: :digit:+}/{field: :alpha:+}",
-            new EmptyRouteHandler());
+        Route route = Route.GET("/contact/{id: :digit:+}/{field: :alpha:+}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact/57/telephone");
@@ -262,8 +257,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPosixHexDigit() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/contact/{id: :xdigit:+}/{field: :digit:+}",
-            new EmptyRouteHandler());
+        Route route = Route.GET("/contact/{id: :xdigit:+}/{field: :digit:+}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact/5ace076/97");
@@ -280,8 +274,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPosixASCII() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/contact/{id: :ascii:+}/{field: :digit:+}",
-            new EmptyRouteHandler());
+        Route route = Route.GET("/contact/{id: :ascii:+}/{field: :digit:+}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact/5ace076/97");
@@ -299,7 +292,7 @@ public class DefaultRouterTest {
     @Test
     public void testWebjarsRoute() throws Exception {
         WebjarsResourceHandler webjars = new WebjarsResourceHandler();
-        Route route = new Route(HttpConstants.Method.GET, webjars.getUriPattern(), new EmptyRouteHandler());
+        Route route = Route.GET(webjars.getUriPattern(), new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/webjars/bootstrap/3.0.2/css/bootstrap.min.css"
@@ -312,7 +305,7 @@ public class DefaultRouterTest {
         // /////////////////////////////////////////////////////////////////////
         // One parameter:
         // /////////////////////////////////////////////////////////////////////
-        router.addRoute(new Route(HttpConstants.Method.GET, "/{name}/dashboard", new EmptyRouteHandler()));
+        router.addRoute(Route.GET("/{name}/dashboard", new EmptyRouteHandler()));
 
         assertEquals(0, router.findRoutes(HttpConstants.Method.GET, "/dashboard").size());
 
@@ -323,7 +316,7 @@ public class DefaultRouterTest {
         // /////////////////////////////////////////////////////////////////////
         // More parameters
         // /////////////////////////////////////////////////////////////////////
-        router.addRoute(new Route(HttpConstants.Method.GET, "/{name}/{id}/dashboard", new EmptyRouteHandler()));
+        router.addRoute(Route.GET("/{name}/{id}/dashboard", new EmptyRouteHandler()));
 
         assertEquals(0, router.findRoutes(HttpConstants.Method.GET, "/dashboard").size());
 
@@ -335,7 +328,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testParametersAndRegex() throws Exception {
-        router.addRoute(new Route(HttpConstants.Method.GET, "/John/{id}/.*", new EmptyRouteHandler()));
+        router.addRoute(Route.GET("/John/{id}/.*", new EmptyRouteHandler()));
 
         List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/John/20/dashboard");
         assertEquals(1, matches.size());
@@ -358,7 +351,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testParametersAndRegexInsideVariableParts() throws Exception {
-        router.addRoute(new Route(HttpConstants.Method.GET, "/public/{path: .*}", new EmptyRouteHandler()));
+        router.addRoute(Route.GET("/public/{path: .*}", new EmptyRouteHandler()));
 
         String pathUnderTest = "/public/css/app.css";
         List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, pathUnderTest);
@@ -382,7 +375,7 @@ public class DefaultRouterTest {
         assertEquals("robots.txt", match.getPathParameters().get("path"));
 
         // multiple parameter parsing with regex expressions
-        router.addRoute(new Route(HttpConstants.Method.GET, "/{name: .+}/photos/{id: [0-9]+}", new EmptyRouteHandler()));
+        router.addRoute(Route.GET("/{name: .+}/photos/{id: [0-9]+}", new EmptyRouteHandler()));
 
         pathUnderTest = "/John/photos/2201";
         matches = router.findRoutes(HttpConstants.Method.GET, pathUnderTest);
@@ -397,7 +390,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testParametersDontCrossSlashes() throws Exception {
-        router.addRoute(new Route(HttpConstants.Method.GET, "/blah/{id}/{id2}/{id3}/morestuff/at/the/end",
+        router.addRoute(Route.GET("/blah/{id}/{id2}/{id3}/morestuff/at/the/end",
             new EmptyRouteHandler()));
 
         // this must match
@@ -409,7 +402,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPointsInRegexDontCrashRegexInTheMiddleOfTheRoute() throws Exception {
-        router.addRoute(new Route(HttpConstants.Method.GET, "/blah/{id}/myname", new EmptyRouteHandler()));
+        router.addRoute(Route.GET("/blah/{id}/myname", new EmptyRouteHandler()));
 
         // the "." in the route should not make any trouble:
         String routeFromServer = "/blah/my.id/myname";
@@ -428,7 +421,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPointsInRegexDontCrashRegexAtEnd() throws Exception {
-        router.addRoute(new Route(HttpConstants.Method.GET, "/blah/{id}", new EmptyRouteHandler()));
+        router.addRoute(Route.GET("/blah/{id}", new EmptyRouteHandler()));
 
         // the "." in the route should not make any trouble:
         // even if it's the last part of the route
@@ -443,14 +436,14 @@ public class DefaultRouterTest {
     public void testRegexInRouteWorksWithEscapes() throws Exception {
         // Test escaped constructs in regex
         // regex with escaped construct in a route
-        router.addRoute(new Route(HttpConstants.Method.GET, "/customers/\\d+", new EmptyRouteHandler()));
+        router.addRoute(Route.GET("/customers/\\d+", new EmptyRouteHandler()));
 
         assertEquals(1, router.findRoutes(HttpConstants.Method.GET, "/customers/1234").size());
         assertEquals(0, router.findRoutes(HttpConstants.Method.GET, "/customers/12ab").size());
 
         // regex with escaped construct in a route with variable parts
         router = new DefaultRouter();
-        router.addRoute(new Route(HttpConstants.Method.GET, "/customers/{id: \\d+}", new EmptyRouteHandler()));
+        router.addRoute(Route.GET("/customers/{id: \\d+}", new EmptyRouteHandler()));
 
         assertEquals(1, router.findRoutes(HttpConstants.Method.GET, "/customers/1234").size());
         assertEquals(0, router.findRoutes(HttpConstants.Method.GET, "/customers/12x").size());
@@ -463,7 +456,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testRegexInRouteWorksWithoutSlashAtTheEnd() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/blah/{id}/.*", new EmptyRouteHandler());
+        Route route = Route.GET("/blah/{id}/.*", new EmptyRouteHandler());
         router.addRoute(route);
 
         // the "." in the real route should work without any problems:
@@ -494,7 +487,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testRouteWithUrlEncodedSlashGetsChoppedCorrectly() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/blah/{id}/.*", new EmptyRouteHandler());
+        Route route = Route.GET("/blah/{id}/.*", new EmptyRouteHandler());
         router.addRoute(route);
 
         // Just a simple test to make sure everything works on a not encoded
@@ -512,7 +505,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testUriForWithRegex() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/user/{email}/{id: .*}", new EmptyRouteHandler());
+        Route route = Route.GET("/user/{email}/{id: .*}", new EmptyRouteHandler());
         router.addRoute(route);
 
         Map<String, Object> parameters = new HashMap<>();
@@ -525,7 +518,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testUriForWithMultipleRegex() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/user/{email: .*}/test/{id: .*}", new EmptyRouteHandler());
+        Route route = Route.GET("/user/{email: .*}/test/{id: .*}", new EmptyRouteHandler());
         router.addRoute(route);
 
         Map<String, Object> parameters = new HashMap<>();
@@ -538,7 +531,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testUriForWithSplat() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/repository/{repo: .*}/ticket/{id: .*}", new EmptyRouteHandler());
+        Route route = Route.GET("/repository/{repo: .*}/ticket/{id: .*}", new EmptyRouteHandler());
         router.addRoute(route);
 
         Map<String, Object> parameters = new HashMap<>();
@@ -557,7 +550,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testUriForWithRegexAndQueryParameters() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/user/{email}/{id: .*}", new EmptyRouteHandler());
+        Route route = Route.GET("/user/{email}/{id: .*}", new EmptyRouteHandler());
         router.addRoute(route);
 
         Map<String, Object> parameters = new HashMap<>();
@@ -571,7 +564,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testUriForWithEncodedParameters() throws Exception {
-        Route route = new Route(HttpConstants.Method.GET, "/user/{email}", new EmptyRouteHandler());
+        Route route = Route.GET("/user/{email}", new EmptyRouteHandler());
         router.addRoute(route);
 
         Map<String, Object> parameters = new HashMap<>();
@@ -584,7 +577,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testExclusionFilter() throws Exception {
-        Route route = new Route(HttpConstants.Method.ALL, "^(?!/(webjars|public)/).*", new EmptyRouteHandler());
+        Route route = Route.ALL("^(?!/(webjars|public)/).*", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/test/route");
@@ -599,7 +592,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testOptionalSuffixGroup() throws Exception {
-        Route route = new Route(HttpConstants.Method.ALL, "/api/contact/{id: [0-9]+}(\\.(json|xml|yaml))?", new EmptyRouteHandler());
+        Route route = Route.ALL("/api/contact/{id: [0-9]+}(\\.(json|xml|yaml))?", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/api/contact/5");
@@ -620,7 +613,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testRequiredSuffixGroup() throws Exception {
-        Route route = new Route(HttpConstants.Method.ALL, "/api/contact/{id: [0-9]+}(\\.(json|xml|yaml))", new EmptyRouteHandler());
+        Route route = Route.ALL("/api/contact/{id: [0-9]+}(\\.(json|xml|yaml))", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/api/contact/5");

--- a/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
@@ -54,7 +54,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testNullUriPatternRoute() throws Exception {
-        Route route = new Route(null, HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, null, new EmptyRouteHandler());
         thrown.expect(Exception.class);
         thrown.expectMessage("The uri pattern cannot be null or empty");
         router.addRoute(route);
@@ -62,7 +62,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testEmptyUriPatternRoute() throws Exception {
-        Route route = new Route("", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "", new EmptyRouteHandler());
         thrown.expect(Exception.class);
         thrown.expectMessage("The uri pattern cannot be null or empty");
         router.addRoute(route);
@@ -70,7 +70,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testUnspecifiedMethodRequestRoute() throws Exception {
-        Route route = new Route("/.*", "", new EmptyRouteHandler());
+        Route route = new Route("", "/.*", new EmptyRouteHandler());
         thrown.expect(Exception.class);
         thrown.expectMessage("Unspecified request method");
         router.addRoute(route);
@@ -78,7 +78,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testAddRoute() throws Exception {
-        Route route = new Route("/.*", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "/.*", new EmptyRouteHandler());
         router.addRoute(route);
 
         assertEquals(1, router.getRoutes().size());
@@ -87,7 +87,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testRemoveRoute() throws Exception {
-        Route route = new Route("/.*", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "/.*", new EmptyRouteHandler());
         router.addRoute(route);
 
         assertEquals(1, router.getRoutes().size());
@@ -100,7 +100,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testFindRoutes() throws Exception {
-        Route route = new Route("/contact", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "/contact", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes("/contact", HttpConstants.Method.GET);
@@ -118,7 +118,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPathParamsRoute() throws Exception {
-        Route route = new Route("/contact/{id}", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "/contact/{id}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes("/contact/3", HttpConstants.Method.GET);
@@ -133,7 +133,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testWildcardRoute() throws Exception {
-        Route route = new Route("/.*", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "/.*", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes("/contact/3", HttpConstants.Method.GET);
@@ -142,7 +142,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPatchRoute() throws Exception {
-        Route route = new Route("/contact/{id}", HttpConstants.Method.PATCH, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.PATCH, "/contact/{id}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes("/contact/3", HttpConstants.Method.PATCH);
@@ -157,7 +157,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testIntIdRoute() throws Exception {
-        Route route = new Route("/contact/{id: [0-9]+}", HttpConstants.Method.PATCH, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.PATCH, "/contact/{id: [0-9]+}", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes("/contact/3", HttpConstants.Method.PATCH);
@@ -175,7 +175,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testIntIdRoute2() throws Exception {
-        Route route = new Route("/contact/{id: [0-9]+}/something/{else: [A-z]*}", HttpConstants.Method.GET,
+        Route route = new Route(HttpConstants.Method.GET, "/contact/{id: [0-9]+}/something/{else: [A-z]*}",
             new EmptyRouteHandler());
         router.addRoute(route);
 
@@ -192,7 +192,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPosixAlpha() throws Exception {
-        Route route = new Route("/user/{login: :alpha:+}/todo/{id: :digit:+}", HttpConstants.Method.GET,
+        Route route = new Route(HttpConstants.Method.GET, "/user/{login: :alpha:+}/todo/{id: :digit:+}",
             new EmptyRouteHandler());
         router.addRoute(route);
 
@@ -210,7 +210,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPosixAlpha2() throws Exception {
-        Route route = new Route("/user/{login: [:digit::alpha:-_\\+\\.]+}/todo/{id: :digit:+}", HttpConstants.Method.GET,
+        Route route = new Route(HttpConstants.Method.GET, "/user/{login: [:digit::alpha:-_\\+\\.]+}/todo/{id: :digit:+}",
             new EmptyRouteHandler());
         router.addRoute(route);
 
@@ -228,7 +228,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPosixAlnum() throws Exception {
-        Route route = new Route("/user/{login: :alnum:+}", HttpConstants.Method.GET,
+        Route route = new Route(HttpConstants.Method.GET, "/user/{login: :alnum:+}",
             new EmptyRouteHandler());
         router.addRoute(route);
 
@@ -244,7 +244,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPosixDigit() throws Exception {
-        Route route = new Route("/contact/{id: :digit:+}/{field: :alpha:+}", HttpConstants.Method.GET,
+        Route route = new Route(HttpConstants.Method.GET, "/contact/{id: :digit:+}/{field: :alpha:+}",
             new EmptyRouteHandler());
         router.addRoute(route);
 
@@ -262,7 +262,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPosixHexDigit() throws Exception {
-        Route route = new Route("/contact/{id: :xdigit:+}/{field: :digit:+}", HttpConstants.Method.GET,
+        Route route = new Route(HttpConstants.Method.GET, "/contact/{id: :xdigit:+}/{field: :digit:+}",
             new EmptyRouteHandler());
         router.addRoute(route);
 
@@ -280,7 +280,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPosixASCII() throws Exception {
-        Route route = new Route("/contact/{id: :ascii:+}/{field: :digit:+}", HttpConstants.Method.GET,
+        Route route = new Route(HttpConstants.Method.GET, "/contact/{id: :ascii:+}/{field: :digit:+}",
             new EmptyRouteHandler());
         router.addRoute(route);
 
@@ -299,7 +299,7 @@ public class DefaultRouterTest {
     @Test
     public void testWebjarsRoute() throws Exception {
         WebjarsResourceHandler webjars = new WebjarsResourceHandler();
-        Route route = new Route(webjars.getUriPattern(), HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, webjars.getUriPattern(), new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> routeMatches = router.findRoutes("/webjars/bootstrap/3.0.2/css/bootstrap.min.css",
@@ -312,7 +312,7 @@ public class DefaultRouterTest {
         // /////////////////////////////////////////////////////////////////////
         // One parameter:
         // /////////////////////////////////////////////////////////////////////
-        router.addRoute(new Route("/{name}/dashboard", HttpConstants.Method.GET, new EmptyRouteHandler()));
+        router.addRoute(new Route(HttpConstants.Method.GET, "/{name}/dashboard", new EmptyRouteHandler()));
 
         assertEquals(0, router.findRoutes("/dashboard", HttpConstants.Method.GET).size());
 
@@ -323,7 +323,7 @@ public class DefaultRouterTest {
         // /////////////////////////////////////////////////////////////////////
         // More parameters
         // /////////////////////////////////////////////////////////////////////
-        router.addRoute(new Route("/{name}/{id}/dashboard", HttpConstants.Method.GET, new EmptyRouteHandler()));
+        router.addRoute(new Route(HttpConstants.Method.GET, "/{name}/{id}/dashboard", new EmptyRouteHandler()));
 
         assertEquals(0, router.findRoutes("/dashboard", HttpConstants.Method.GET).size());
 
@@ -335,7 +335,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testParametersAndRegex() throws Exception {
-        router.addRoute(new Route("/John/{id}/.*", HttpConstants.Method.GET, new EmptyRouteHandler()));
+        router.addRoute(new Route(HttpConstants.Method.GET, "/John/{id}/.*", new EmptyRouteHandler()));
 
         List<RouteMatch> matches = router.findRoutes("/John/20/dashboard", HttpConstants.Method.GET);
         assertEquals(1, matches.size());
@@ -358,7 +358,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testParametersAndRegexInsideVariableParts() throws Exception {
-        router.addRoute(new Route("/public/{path: .*}", HttpConstants.Method.GET, new EmptyRouteHandler()));
+        router.addRoute(new Route(HttpConstants.Method.GET, "/public/{path: .*}", new EmptyRouteHandler()));
 
         String pathUnderTest = "/public/css/app.css";
         List<RouteMatch> matches = router.findRoutes(pathUnderTest, HttpConstants.Method.GET);
@@ -382,7 +382,7 @@ public class DefaultRouterTest {
         assertEquals("robots.txt", match.getPathParameters().get("path"));
 
         // multiple parameter parsing with regex expressions
-        router.addRoute(new Route("/{name: .+}/photos/{id: [0-9]+}", HttpConstants.Method.GET, new EmptyRouteHandler()));
+        router.addRoute(new Route(HttpConstants.Method.GET, "/{name: .+}/photos/{id: [0-9]+}", new EmptyRouteHandler()));
 
         pathUnderTest = "/John/photos/2201";
         matches = router.findRoutes(pathUnderTest, HttpConstants.Method.GET);
@@ -397,7 +397,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testParametersDontCrossSlashes() throws Exception {
-        router.addRoute(new Route("/blah/{id}/{id2}/{id3}/morestuff/at/the/end", HttpConstants.Method.GET,
+        router.addRoute(new Route(HttpConstants.Method.GET, "/blah/{id}/{id2}/{id3}/morestuff/at/the/end",
             new EmptyRouteHandler()));
 
         // this must match
@@ -409,7 +409,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPointsInRegexDontCrashRegexInTheMiddleOfTheRoute() throws Exception {
-        router.addRoute(new Route("/blah/{id}/myname", HttpConstants.Method.GET, new EmptyRouteHandler()));
+        router.addRoute(new Route(HttpConstants.Method.GET, "/blah/{id}/myname", new EmptyRouteHandler()));
 
         // the "." in the route should not make any trouble:
         String routeFromServer = "/blah/my.id/myname";
@@ -428,7 +428,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testPointsInRegexDontCrashRegexAtEnd() throws Exception {
-        router.addRoute(new Route("/blah/{id}", HttpConstants.Method.GET, new EmptyRouteHandler()));
+        router.addRoute(new Route(HttpConstants.Method.GET, "/blah/{id}", new EmptyRouteHandler()));
 
         // the "." in the route should not make any trouble:
         // even if it's the last part of the route
@@ -443,14 +443,14 @@ public class DefaultRouterTest {
     public void testRegexInRouteWorksWithEscapes() throws Exception {
         // Test escaped constructs in regex
         // regex with escaped construct in a route
-        router.addRoute(new Route("/customers/\\d+", HttpConstants.Method.GET, new EmptyRouteHandler()));
+        router.addRoute(new Route(HttpConstants.Method.GET, "/customers/\\d+", new EmptyRouteHandler()));
 
         assertEquals(1, router.findRoutes("/customers/1234", HttpConstants.Method.GET).size());
         assertEquals(0, router.findRoutes("/customers/12ab", HttpConstants.Method.GET).size());
 
         // regex with escaped construct in a route with variable parts
         router = new DefaultRouter();
-        router.addRoute(new Route("/customers/{id: \\d+}", HttpConstants.Method.GET, new EmptyRouteHandler()));
+        router.addRoute(new Route(HttpConstants.Method.GET, "/customers/{id: \\d+}", new EmptyRouteHandler()));
 
         assertEquals(1, router.findRoutes("/customers/1234", HttpConstants.Method.GET).size());
         assertEquals(0, router.findRoutes("/customers/12x", HttpConstants.Method.GET).size());
@@ -463,7 +463,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testRegexInRouteWorksWithoutSlashAtTheEnd() throws Exception {
-        Route route = new Route("/blah/{id}/.*", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "/blah/{id}/.*", new EmptyRouteHandler());
         router.addRoute(route);
 
         // the "." in the real route should work without any problems:
@@ -494,7 +494,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testRouteWithUrlEncodedSlashGetsChoppedCorrectly() throws Exception {
-        Route route = new Route("/blah/{id}/.*", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "/blah/{id}/.*", new EmptyRouteHandler());
         router.addRoute(route);
 
         // Just a simple test to make sure everything works on a not encoded
@@ -512,10 +512,10 @@ public class DefaultRouterTest {
 
     @Test
     public void testUriForWithRegex() throws Exception {
-        Route route = new Route("/user/{email}/{id: .*}", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "/user/{email}/{id: .*}", new EmptyRouteHandler());
         router.addRoute(route);
 
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("email", "test@test.com");
         parameters.put("id", 5);
         String path = router.uriFor(route.getUriPattern(), parameters);
@@ -525,10 +525,10 @@ public class DefaultRouterTest {
 
     @Test
     public void testUriForWithMultipleRegex() throws Exception {
-        Route route = new Route("/user/{email: .*}/test/{id: .*}", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "/user/{email: .*}/test/{id: .*}", new EmptyRouteHandler());
         router.addRoute(route);
 
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("email", "test@test.com");
         parameters.put("id", 5);
         String path = router.uriFor(route.getUriPattern(), parameters);
@@ -538,10 +538,10 @@ public class DefaultRouterTest {
 
     @Test
     public void testUriForWithSplat() throws Exception {
-        Route route = new Route("/repository/{repo: .*}/ticket/{id: .*}", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "/repository/{repo: .*}/ticket/{id: .*}", new EmptyRouteHandler());
         router.addRoute(route);
 
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("repo", "test/myrepo");
         parameters.put("id", 5);
         String path = router.uriFor(route.getUriPattern(), parameters);
@@ -557,7 +557,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testUriForWithRegexAndQueryParameters() throws Exception {
-        Route route = new Route("/user/{email}/{id: .*}", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "/user/{email}/{id: .*}", new EmptyRouteHandler());
         router.addRoute(route);
 
         Map<String, Object> parameters = new HashMap<>();
@@ -571,7 +571,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testUriForWithEncodedParameters() throws Exception {
-        Route route = new Route("/user/{email}", HttpConstants.Method.GET, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.GET, "/user/{email}", new EmptyRouteHandler());
         router.addRoute(route);
 
         Map<String, Object> parameters = new HashMap<>();
@@ -584,7 +584,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testExclusionFilter() throws Exception {
-        Route route = new Route("^(?!/(webjars|public)/).*", HttpConstants.Method.ALL, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.ALL, "^(?!/(webjars|public)/).*", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> matches = router.findRoutes("/test/route", HttpConstants.Method.GET);
@@ -599,7 +599,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testOptionalSuffixGroup() throws Exception {
-        Route route = new Route("/api/contact/{id: [0-9]+}(\\.(json|xml|yaml))?", HttpConstants.Method.ALL, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.ALL, "/api/contact/{id: [0-9]+}(\\.(json|xml|yaml))?", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> matches = router.findRoutes("/api/contact/5", HttpConstants.Method.GET);
@@ -620,7 +620,7 @@ public class DefaultRouterTest {
 
     @Test
     public void testRequiredSuffixGroup() throws Exception {
-        Route route = new Route("/api/contact/{id: [0-9]+}(\\.(json|xml|yaml))", HttpConstants.Method.ALL, new EmptyRouteHandler());
+        Route route = new Route(HttpConstants.Method.ALL, "/api/contact/{id: [0-9]+}(\\.(json|xml|yaml))", new EmptyRouteHandler());
         router.addRoute(route);
 
         List<RouteMatch> matches = router.findRoutes("/api/contact/5", HttpConstants.Method.GET);

--- a/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
@@ -103,15 +103,15 @@ public class DefaultRouterTest {
         Route route = new Route(HttpConstants.Method.GET, "/contact", new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/contact", HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact");
         assertNotNull(routeMatches);
         assertEquals(1, routeMatches.size());
 
-        routeMatches = router.findRoutes("/contact", HttpConstants.Method.POST);
+        routeMatches = router.findRoutes(HttpConstants.Method.POST, "/contact");
         assertNotNull(routeMatches);
         assertEquals(0, routeMatches.size());
 
-        routeMatches = router.findRoutes("/", HttpConstants.Method.GET);
+        routeMatches = router.findRoutes(HttpConstants.Method.GET, "/");
         assertNotNull(routeMatches);
         assertEquals(0, routeMatches.size());
     }
@@ -121,7 +121,7 @@ public class DefaultRouterTest {
         Route route = new Route(HttpConstants.Method.GET, "/contact/{id}", new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/contact/3", HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact/3");
         assertEquals(1, routeMatches.size());
 
         Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
@@ -136,7 +136,7 @@ public class DefaultRouterTest {
         Route route = new Route(HttpConstants.Method.GET, "/.*", new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/contact/3", HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact/3");
         assertEquals(1, routeMatches.size());
     }
 
@@ -145,7 +145,7 @@ public class DefaultRouterTest {
         Route route = new Route(HttpConstants.Method.PATCH, "/contact/{id}", new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/contact/3", HttpConstants.Method.PATCH);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.PATCH, "/contact/3");
         assertEquals(1, routeMatches.size());
 
         Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
@@ -160,7 +160,7 @@ public class DefaultRouterTest {
         Route route = new Route(HttpConstants.Method.PATCH, "/contact/{id: [0-9]+}", new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/contact/3", HttpConstants.Method.PATCH);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.PATCH, "/contact/3");
         assertEquals(1, routeMatches.size());
 
         Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
@@ -169,7 +169,7 @@ public class DefaultRouterTest {
         assertTrue(pathParameters.containsKey("id"));
         assertEquals(String.valueOf(3), pathParameters.get("id"));
 
-        routeMatches = router.findRoutes("/contact/a", HttpConstants.Method.PATCH);
+        routeMatches = router.findRoutes(HttpConstants.Method.PATCH, "/contact/a");
         assertEquals(0, routeMatches.size());
     }
 
@@ -179,7 +179,7 @@ public class DefaultRouterTest {
             new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/contact/3/something/borrowed", HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact/3/something/borrowed");
         assertEquals(1, routeMatches.size());
 
         Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
@@ -196,7 +196,7 @@ public class DefaultRouterTest {
             new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/user/jämяs/todo/57", HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/user/jämяs/todo/57");
         assertEquals(1, routeMatches.size());
 
         Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
@@ -214,7 +214,7 @@ public class DefaultRouterTest {
             new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/user/j.ä_я3-s/todo/57", HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/user/j.ä_я3-s/todo/57");
         assertEquals(1, routeMatches.size());
 
         Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
@@ -232,7 +232,7 @@ public class DefaultRouterTest {
             new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/user/james5", HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/user/james5");
         assertEquals(1, routeMatches.size());
 
         Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
@@ -248,7 +248,7 @@ public class DefaultRouterTest {
             new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/contact/57/telephone", HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact/57/telephone");
         assertEquals(1, routeMatches.size());
 
         Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
@@ -266,7 +266,7 @@ public class DefaultRouterTest {
             new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/contact/5ace076/97", HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact/5ace076/97");
         assertEquals(1, routeMatches.size());
 
         Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
@@ -284,7 +284,7 @@ public class DefaultRouterTest {
             new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/contact/5ace076/97", HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/contact/5ace076/97");
         assertEquals(1, routeMatches.size());
 
         Map<String, String> pathParameters = routeMatches.get(0).getPathParameters();
@@ -302,8 +302,8 @@ public class DefaultRouterTest {
         Route route = new Route(HttpConstants.Method.GET, webjars.getUriPattern(), new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> routeMatches = router.findRoutes("/webjars/bootstrap/3.0.2/css/bootstrap.min.css",
-            HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, "/webjars/bootstrap/3.0.2/css/bootstrap.min.css"
+        );
         assertEquals(1, routeMatches.size());
     }
 
@@ -314,9 +314,9 @@ public class DefaultRouterTest {
         // /////////////////////////////////////////////////////////////////////
         router.addRoute(new Route(HttpConstants.Method.GET, "/{name}/dashboard", new EmptyRouteHandler()));
 
-        assertEquals(0, router.findRoutes("/dashboard", HttpConstants.Method.GET).size());
+        assertEquals(0, router.findRoutes(HttpConstants.Method.GET, "/dashboard").size());
 
-        List<RouteMatch> matches = router.findRoutes("/John/dashboard", HttpConstants.Method.GET);
+        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/John/dashboard");
         assertEquals(1, matches.size());
         assertEquals("John", matches.get(0).getPathParameters().get("name"));
 
@@ -325,9 +325,9 @@ public class DefaultRouterTest {
         // /////////////////////////////////////////////////////////////////////
         router.addRoute(new Route(HttpConstants.Method.GET, "/{name}/{id}/dashboard", new EmptyRouteHandler()));
 
-        assertEquals(0, router.findRoutes("/dashboard", HttpConstants.Method.GET).size());
+        assertEquals(0, router.findRoutes(HttpConstants.Method.GET, "/dashboard").size());
 
-        matches = router.findRoutes("/John/20/dashboard", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/John/20/dashboard");
         assertEquals(1, matches.size());
         assertEquals("John", matches.get(0).getPathParameters().get("name"));
         assertEquals("20", matches.get(0).getPathParameters().get("id"));
@@ -337,19 +337,19 @@ public class DefaultRouterTest {
     public void testParametersAndRegex() throws Exception {
         router.addRoute(new Route(HttpConstants.Method.GET, "/John/{id}/.*", new EmptyRouteHandler()));
 
-        List<RouteMatch> matches = router.findRoutes("/John/20/dashboard", HttpConstants.Method.GET);
+        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/John/20/dashboard");
         assertEquals(1, matches.size());
         RouteMatch match = matches.get(0);
         assertEquals(1, match.getPathParameters().size());
         assertEquals("20", match.getPathParameters().get("id"));
 
-        matches = router.findRoutes("/John/20/admin", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/John/20/admin");
         assertEquals(1, matches.size());
         match = matches.get(0);
         assertEquals(1, match.getPathParameters().size());
         assertEquals("20", match.getPathParameters().get("id"));
 
-        matches = router.findRoutes("/John/20/mock", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/John/20/mock");
         assertEquals(1, matches.size());
         match = matches.get(0);
         assertEquals(1, match.getPathParameters().size());
@@ -361,21 +361,21 @@ public class DefaultRouterTest {
         router.addRoute(new Route(HttpConstants.Method.GET, "/public/{path: .*}", new EmptyRouteHandler()));
 
         String pathUnderTest = "/public/css/app.css";
-        List<RouteMatch> matches = router.findRoutes(pathUnderTest, HttpConstants.Method.GET);
+        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, pathUnderTest);
         assertEquals(1, matches.size());
         RouteMatch match = matches.get(0);
         assertEquals(1, match.getPathParameters().size());
         assertEquals("css/app.css", match.getPathParameters().get("path"));
 
         pathUnderTest = "/public/js/main.js";
-        matches = router.findRoutes(pathUnderTest, HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, pathUnderTest);
         assertEquals(1, matches.size());
         match = matches.get(0);
         assertEquals(1, match.getPathParameters().size());
         assertEquals("js/main.js", match.getPathParameters().get("path"));
 
         pathUnderTest = "/public/robots.txt";
-        matches = router.findRoutes(pathUnderTest, HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, pathUnderTest);
         assertEquals(1, matches.size());
         match = matches.get(0);
         assertEquals(1, match.getPathParameters().size());
@@ -385,14 +385,14 @@ public class DefaultRouterTest {
         router.addRoute(new Route(HttpConstants.Method.GET, "/{name: .+}/photos/{id: [0-9]+}", new EmptyRouteHandler()));
 
         pathUnderTest = "/John/photos/2201";
-        matches = router.findRoutes(pathUnderTest, HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, pathUnderTest);
         assertEquals(1, matches.size());
         match = matches.get(0);
         assertEquals(2, match.getPathParameters().size());
         assertEquals("John", match.getPathParameters().get("name"));
         assertEquals("2201", match.getPathParameters().get("id"));
 
-        assertEquals(0, router.findRoutes("John/photos/first", HttpConstants.Method.GET).size());
+        assertEquals(0, router.findRoutes(HttpConstants.Method.GET, "John/photos/first").size());
     }
 
     @Test
@@ -401,10 +401,10 @@ public class DefaultRouterTest {
             new EmptyRouteHandler()));
 
         // this must match
-        assertEquals(1, router.findRoutes("/blah/id/id2/id3/morestuff/at/the/end", HttpConstants.Method.GET).size());
+        assertEquals(1, router.findRoutes(HttpConstants.Method.GET, "/blah/id/id2/id3/morestuff/at/the/end").size());
 
         // this should not match as the last "end" is missing
-        assertEquals(0, router.findRoutes("/blah/id/id2/id3/morestuff/at/the", HttpConstants.Method.GET).size());
+        assertEquals(0, router.findRoutes(HttpConstants.Method.GET, "/blah/id/id2/id3/morestuff/at/the").size());
     }
 
     @Test
@@ -414,7 +414,7 @@ public class DefaultRouterTest {
         // the "." in the route should not make any trouble:
         String routeFromServer = "/blah/my.id/myname";
 
-        List<RouteMatch> matches = router.findRoutes(routeFromServer, HttpConstants.Method.GET);
+        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, routeFromServer);
         assertEquals(1, matches.size());
         RouteMatch match = matches.get(0);
         assertEquals(1, match.getPathParameters().size());
@@ -422,7 +422,7 @@ public class DefaultRouterTest {
 
         // and another slightly different route
         routeFromServer = "/blah/my.id/myname/should_not_match";
-        matches = router.findRoutes(routeFromServer, HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, routeFromServer);
         assertEquals(0, matches.size());
     }
 
@@ -432,7 +432,7 @@ public class DefaultRouterTest {
 
         // the "." in the route should not make any trouble:
         // even if it's the last part of the route
-        List<RouteMatch> matches = router.findRoutes("/blah/my.id", HttpConstants.Method.GET);
+        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/blah/my.id");
         assertEquals(1, matches.size());
         RouteMatch match = matches.get(0);
         assertEquals(1, match.getPathParameters().size());
@@ -445,17 +445,17 @@ public class DefaultRouterTest {
         // regex with escaped construct in a route
         router.addRoute(new Route(HttpConstants.Method.GET, "/customers/\\d+", new EmptyRouteHandler()));
 
-        assertEquals(1, router.findRoutes("/customers/1234", HttpConstants.Method.GET).size());
-        assertEquals(0, router.findRoutes("/customers/12ab", HttpConstants.Method.GET).size());
+        assertEquals(1, router.findRoutes(HttpConstants.Method.GET, "/customers/1234").size());
+        assertEquals(0, router.findRoutes(HttpConstants.Method.GET, "/customers/12ab").size());
 
         // regex with escaped construct in a route with variable parts
         router = new DefaultRouter();
         router.addRoute(new Route(HttpConstants.Method.GET, "/customers/{id: \\d+}", new EmptyRouteHandler()));
 
-        assertEquals(1, router.findRoutes("/customers/1234", HttpConstants.Method.GET).size());
-        assertEquals(0, router.findRoutes("/customers/12x", HttpConstants.Method.GET).size());
+        assertEquals(1, router.findRoutes(HttpConstants.Method.GET, "/customers/1234").size());
+        assertEquals(0, router.findRoutes(HttpConstants.Method.GET, "/customers/12x").size());
 
-        RouteMatch routeMatch = router.findRoutes("/customers/1234", HttpConstants.Method.GET).get(0);
+        RouteMatch routeMatch = router.findRoutes(HttpConstants.Method.GET, "/customers/1234").get(0);
         Map<String, String> map = routeMatch.getPathParameters();
         assertEquals(1, map.size());
         assertEquals("1234", map.get("id"));
@@ -469,7 +469,7 @@ public class DefaultRouterTest {
         // the "." in the real route should work without any problems:
         String routeFromServer = "/blah/my.id/and/some/more/stuff";
 
-        List<RouteMatch> routeMatches = router.findRoutes(routeFromServer, HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, routeFromServer);
         assertEquals(1, routeMatches.size());
         RouteMatch routeMatch = routeMatches.get(0);
         assertEquals(route, routeMatch.getRoute());
@@ -480,7 +480,7 @@ public class DefaultRouterTest {
         // another slightly different route.
         routeFromServer = "/blah/my.id/";
 
-        routeMatches = router.findRoutes(routeFromServer, HttpConstants.Method.GET);
+        routeMatches = router.findRoutes(HttpConstants.Method.GET, routeFromServer);
         assertEquals(1, routeMatches.size());
         routeMatch = routeMatches.get(0);
         assertEquals(route, routeMatch.getRoute());
@@ -488,7 +488,7 @@ public class DefaultRouterTest {
         assertEquals(1, routeMatch.getPathParameters().size());
         assertEquals("my.id", routeMatch.getPathParameters().get("id"));
 
-        routeMatches = router.findRoutes("/blah/my.id", HttpConstants.Method.GET);
+        routeMatches = router.findRoutes(HttpConstants.Method.GET, "/blah/my.id");
         assertEquals(0, routeMatches.size());
     }
 
@@ -501,7 +501,7 @@ public class DefaultRouterTest {
         // uri: decoded this would be /blah/my/id/and/some/more/stuff
         String routeFromServer = "/blah/my%2fid/and/some/more/stuff";
 
-        List<RouteMatch> routeMatches = router.findRoutes(routeFromServer, HttpConstants.Method.GET);
+        List<RouteMatch> routeMatches = router.findRoutes(HttpConstants.Method.GET, routeFromServer);
         assertEquals(1, routeMatches.size());
         RouteMatch routeMatch = routeMatches.get(0);
         assertEquals(route, routeMatch.getRoute());
@@ -548,7 +548,7 @@ public class DefaultRouterTest {
 
         assertThat(path, equalTo("/repository/test/myrepo/ticket/5"));
 
-        List<RouteMatch> matches = router.findRoutes("/repository/test/myrepo/ticket/5", HttpConstants.Method.GET);
+        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/repository/test/myrepo/ticket/5");
 
         assertFalse(matches.isEmpty());
         assertEquals("test/myrepo", matches.get(0).getPathParameters().get("repo"));
@@ -587,13 +587,13 @@ public class DefaultRouterTest {
         Route route = new Route(HttpConstants.Method.ALL, "^(?!/(webjars|public)/).*", new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> matches = router.findRoutes("/test/route", HttpConstants.Method.GET);
+        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/test/route");
         assertEquals(1, matches.size());
 
-        matches = router.findRoutes("/webjars/route", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/webjars/route");
         assertEquals(0, matches.size());
 
-        matches = router.findRoutes("/public/route", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/public/route");
         assertEquals(0, matches.size());
     }
 
@@ -602,19 +602,19 @@ public class DefaultRouterTest {
         Route route = new Route(HttpConstants.Method.ALL, "/api/contact/{id: [0-9]+}(\\.(json|xml|yaml))?", new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> matches = router.findRoutes("/api/contact/5", HttpConstants.Method.GET);
+        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/api/contact/5");
         assertEquals(1, matches.size());
 
-        matches = router.findRoutes("/api/contact/5.json", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/api/contact/5.json");
         assertEquals(1, matches.size());
 
-        matches = router.findRoutes("/api/contact/5.xml", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/api/contact/5.xml");
         assertEquals(1, matches.size());
 
-        matches = router.findRoutes("/api/contact/5.yaml", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/api/contact/5.yaml");
         assertEquals(1, matches.size());
 
-        matches = router.findRoutes("/api/contact/5.unknown", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/api/contact/5.unknown");
         assertEquals(0, matches.size());
     }
 
@@ -623,19 +623,19 @@ public class DefaultRouterTest {
         Route route = new Route(HttpConstants.Method.ALL, "/api/contact/{id: [0-9]+}(\\.(json|xml|yaml))", new EmptyRouteHandler());
         router.addRoute(route);
 
-        List<RouteMatch> matches = router.findRoutes("/api/contact/5", HttpConstants.Method.GET);
+        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/api/contact/5");
         assertEquals(0, matches.size());
 
-        matches = router.findRoutes("/api/contact/5.json", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/api/contact/5.json");
         assertEquals(1, matches.size());
 
-        matches = router.findRoutes("/api/contact/5.xml", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/api/contact/5.xml");
         assertEquals(1, matches.size());
 
-        matches = router.findRoutes("/api/contact/5.yaml", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/api/contact/5.yaml");
         assertEquals(1, matches.size());
 
-        matches = router.findRoutes("/api/contact/5.unknown", HttpConstants.Method.GET);
+        matches = router.findRoutes(HttpConstants.Method.GET, "/api/contact/5.unknown");
         assertEquals(0, matches.size());
     }
 


### PR DESCRIPTION
This pull request comes with three changes:
- Change order of requestMethod, uriPattern (Route constructor) according to #138
- Change order of requestMethod, uriPattern (Route.findRoutes)
- Add static factory methods for GET, POST, ... in Route class

I think that code is more clear. The signature for the Route constructor was changed but I think that it's not a big problem because nobody uses the Route constructor directly.

I will add some javadoc if you are OK with these modifications.