### PR TITLE
Versioning public resources (#228)

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -408,7 +408,7 @@ public class DefaultRouter implements Router {
 
     private String uriFor(PatternBinding binding, Map<String, Object> parameters) {
         Route route = binding.getRoute();
-        boolean isResourceRoute = UrlResourceHandler.class.isAssignableFrom(route.getRouteHandler().getClass());
+        boolean isResourceRoute = ResourceHandler.class.isAssignableFrom(route.getRouteHandler().getClass());
 
         List<String> parameterNames = binding.getParameterNames();
         if (!parameters.keySet().containsAll(parameterNames)) {
@@ -429,8 +429,7 @@ public class DefaultRouter implements Router {
             while (matcher.find()) {
                 String pathValue = parameterPair.getValue().toString();
                 if (isResourceRoute && ResourceHandler.PATH_PARAMETER.equals(parameterPair.getKey())) {
-                    String versionedResourcePath = ((UrlResourceHandler) route.getRouteHandler()).injectVersion(pathValue);
-                    pathValue = versionedResourcePath;
+                    pathValue = ((ResourceHandler) route.getRouteHandler()).injectVersion(pathValue);
                 }
                 matcher.appendReplacement(sb, pathValue);
                 foundAsPathParameter = true;

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -429,7 +429,10 @@ public class DefaultRouter implements Router {
             while (matcher.find()) {
                 String pathValue = parameterPair.getValue().toString();
                 if (isResourceRoute && ResourceHandler.PATH_PARAMETER.equals(parameterPair.getKey())) {
-                    pathValue = ((ResourceHandler) route.getRouteHandler()).injectVersion(pathValue);
+                    ResourceHandler resourceHandler = (ResourceHandler) route.getRouteHandler();
+                    if (resourceHandler.isVersioned()) {
+                        pathValue = resourceHandler.injectVersion(pathValue);
+                    }
                 }
                 matcher.appendReplacement(sb, pathValue);
                 foundAsPathParameter = true;

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -430,7 +430,6 @@ public class DefaultRouter implements Router {
                 String pathValue = parameterPair.getValue().toString();
                 if (isResourceRoute && ResourceHandler.PATH_PARAMETER.equals(parameterPair.getKey())) {
                     String versionedResourcePath = ((UrlResourceHandler) route.getRouteHandler()).injectVersion(pathValue);
-                    log.debug("Inject version in resource path: '{}' => '{}'", pathValue, versionedResourcePath);
                     pathValue = versionedResourcePath;
                 }
                 matcher.appendReplacement(sb, pathValue);

--- a/pippo-core/src/main/java/ro/pippo/core/route/ResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/ResourceHandler.java
@@ -46,11 +46,7 @@ public abstract class ResourceHandler implements RouteHandler {
         log.trace("Request resource '{}'", resourcePath);
 
         if (versioned) {
-            String unversionedResourcePath = removeVersion(resourcePath);
-            if (!unversionedResourcePath.equals(resourcePath)) {
-                log.trace("Remove version from resource path: '{}' => '{}'", resourcePath, unversionedResourcePath);
-                resourcePath = unversionedResourcePath;
-            }
+            resourcePath = removeVersion(resourcePath);
         }
 
         handleResource(resourcePath, routeContext);

--- a/pippo-core/src/main/java/ro/pippo/core/route/ResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/ResourceHandler.java
@@ -30,6 +30,7 @@ public abstract class ResourceHandler implements RouteHandler {
     public static final String PATH_PARAMETER = "path";
 
     private final String uriPattern;
+    private boolean versioned = true;
 
     public ResourceHandler(String urlPath) {
         this.uriPattern = String.format("/%s/{%s: .*}", getNormalizedPath(urlPath), PATH_PARAMETER);
@@ -44,10 +45,12 @@ public abstract class ResourceHandler implements RouteHandler {
         String resourcePath = getResourcePath(routeContext);
         log.trace("Request resource '{}'", resourcePath);
 
-        String unversionedResourcePath = removeVersion(resourcePath);
-        if (!unversionedResourcePath.equals(resourcePath)) {
-            log.trace("Remove version from resource path: '{}' => '{}'", resourcePath, unversionedResourcePath);
-            resourcePath = unversionedResourcePath;
+        if (versioned) {
+            String unversionedResourcePath = removeVersion(resourcePath);
+            if (!unversionedResourcePath.equals(resourcePath)) {
+                log.trace("Remove version from resource path: '{}' => '{}'", resourcePath, unversionedResourcePath);
+                resourcePath = unversionedResourcePath;
+            }
         }
 
         handleResource(resourcePath, routeContext);
@@ -66,6 +69,14 @@ public abstract class ResourceHandler implements RouteHandler {
      * Remove version fragment.
      */
     public abstract String removeVersion(String resourcePath);
+
+    public boolean isVersioned() {
+        return versioned;
+    }
+
+    public void setVersioned(boolean versioned) {
+        this.versioned = versioned;
+    }
 
     protected String getResourcePath(RouteContext routeContext) {
         return getNormalizedPath(routeContext.getParameter(PATH_PARAMETER).toString());

--- a/pippo-core/src/main/java/ro/pippo/core/route/ResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/ResourceHandler.java
@@ -43,12 +43,29 @@ public abstract class ResourceHandler implements RouteHandler {
     public final void handle(RouteContext routeContext) {
         String resourcePath = getResourcePath(routeContext);
         log.trace("Request resource '{}'", resourcePath);
+
+        String unversionedResourcePath = removeVersion(resourcePath);
+        if (!unversionedResourcePath.equals(resourcePath)) {
+            log.trace("Remove version from resource path: '{}' => '{}'", resourcePath, unversionedResourcePath);
+            resourcePath = unversionedResourcePath;
+        }
+
         handleResource(resourcePath, routeContext);
 
         routeContext.next();
     }
 
     public abstract void handleResource(String resourcePath, RouteContext routeContext);
+
+    /**
+     * Inject version fragment.
+     */
+    public abstract String injectVersion(String resourcePath);
+
+    /**
+     * Remove version fragment.
+     */
+    public abstract String removeVersion(String resourcePath);
 
     protected String getResourcePath(RouteContext routeContext) {
         return getNormalizedPath(routeContext.getParameter(PATH_PARAMETER).toString());

--- a/pippo-core/src/main/java/ro/pippo/core/route/UrlResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/UrlResourceHandler.java
@@ -98,7 +98,10 @@ public abstract class UrlResourceHandler extends ResourceHandler {
             int endIndex = matcher.end() - 1;
             String version = resourcePath.substring(startIndex + 1, endIndex);
 
-            return resourcePath.replace(version, "");
+            String unversionedResourcePath = resourcePath.replace(version, "");
+            log.trace("Remove version from resource path: '{}' => '{}'", resourcePath, unversionedResourcePath);
+
+            return unversionedResourcePath;
         }
 
         return resourcePath;

--- a/pippo-core/src/main/java/ro/pippo/core/route/UrlResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/UrlResourceHandler.java
@@ -23,6 +23,8 @@ import ro.pippo.core.util.StringUtils;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Serves static resources.
@@ -33,12 +35,20 @@ public abstract class UrlResourceHandler extends ResourceHandler {
 
     private static final Logger log = LoggerFactory.getLogger(UrlResourceHandler.class);
 
+    private static final Pattern VERSION_PATTERN = Pattern.compile("-[0-9]+\\.");
+
     public UrlResourceHandler(String urlPath) {
         super(urlPath);
     }
 
     @Override
     public final void handleResource(String resourcePath, RouteContext routeContext) {
+        String unversionedResourcePath = removeVersion(resourcePath);
+        if (!unversionedResourcePath.equals(resourcePath)) {
+            log.debug("Remove version from resource path: '{}' => '{}'", resourcePath, unversionedResourcePath);
+            resourcePath = unversionedResourcePath;
+        }
+
         URL url = getResourceUrl(resourcePath);
         if (url == null) {
             routeContext.getResponse().notFound().commit();
@@ -48,6 +58,50 @@ public abstract class UrlResourceHandler extends ResourceHandler {
     }
 
     public abstract URL getResourceUrl(String resourcePath);
+
+    /**
+     * Inject version fragment.
+     */
+    public String injectVersion(String resourcePath) {
+        URL resourceUrl = getResourceUrl(resourcePath);
+        try {
+            long lastModified = resourceUrl.openConnection().getLastModified();
+
+            // check for extension
+            int extensionAt = resourcePath.lastIndexOf('.');
+
+            StringBuilder versionedResourcePath = new StringBuilder();
+
+            if (extensionAt == -1) {
+                versionedResourcePath.append(resourcePath);
+                versionedResourcePath.append("-").append(lastModified);
+            } else {
+                versionedResourcePath.append(resourcePath.substring(0, extensionAt));
+                versionedResourcePath.append("-").append(lastModified);
+                versionedResourcePath.append(resourcePath.substring(extensionAt, resourcePath.length()));
+            }
+
+            return versionedResourcePath.toString();
+        } catch (IOException e) {
+            throw new PippoRuntimeException("Failed to read lastModified property for {}", e, resourceUrl);
+        }
+    }
+
+    /**
+     * Remove version fragment.
+     */
+    public String removeVersion(String resourcePath) {
+        Matcher matcher = VERSION_PATTERN.matcher(resourcePath);
+        if (matcher.find()) {
+            int startIndex = matcher.start() - 1;
+            int endIndex = matcher.end() - 1;
+            String version = resourcePath.substring(startIndex + 1, endIndex);
+
+            return resourcePath.replace(version, "");
+        }
+
+        return resourcePath;
+    }
 
     protected void streamResource(URL resourceUrl, RouteContext routeContext) {
         try {

--- a/pippo-core/src/main/java/ro/pippo/core/route/UrlResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/UrlResourceHandler.java
@@ -35,7 +35,7 @@ public abstract class UrlResourceHandler extends ResourceHandler {
 
     private static final Logger log = LoggerFactory.getLogger(UrlResourceHandler.class);
 
-    private static final Pattern VERSION_PATTERN = Pattern.compile("-[0-9]+\\.");
+    private static final Pattern VERSION_PATTERN = Pattern.compile("-ver-[0-9]+\\.");
 
     public UrlResourceHandler(String urlPath) {
         super(urlPath);
@@ -45,7 +45,7 @@ public abstract class UrlResourceHandler extends ResourceHandler {
     public final void handleResource(String resourcePath, RouteContext routeContext) {
         String unversionedResourcePath = removeVersion(resourcePath);
         if (!unversionedResourcePath.equals(resourcePath)) {
-            log.debug("Remove version from resource path: '{}' => '{}'", resourcePath, unversionedResourcePath);
+            log.trace("Remove version from resource path: '{}' => '{}'", resourcePath, unversionedResourcePath);
             resourcePath = unversionedResourcePath;
         }
 
@@ -74,12 +74,14 @@ public abstract class UrlResourceHandler extends ResourceHandler {
 
             if (extensionAt == -1) {
                 versionedResourcePath.append(resourcePath);
-                versionedResourcePath.append("-").append(lastModified);
+                versionedResourcePath.append("-ver-").append(lastModified);
             } else {
                 versionedResourcePath.append(resourcePath.substring(0, extensionAt));
-                versionedResourcePath.append("-").append(lastModified);
+                versionedResourcePath.append("-ver-").append(lastModified);
                 versionedResourcePath.append(resourcePath.substring(extensionAt, resourcePath.length()));
             }
+
+            log.trace("Inject version in resource path: '{}' => '{}'", resourcePath, versionedResourcePath);
 
             return versionedResourcePath.toString();
         } catch (IOException e) {

--- a/pippo-core/src/main/java/ro/pippo/core/route/UrlResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/UrlResourceHandler.java
@@ -56,8 +56,7 @@ public abstract class UrlResourceHandler extends ResourceHandler {
     protected String getResourceVersion(String resourcePath) {
         URL resourceUrl = getResourceUrl(resourcePath);
         try {
-            long lastModified = resourceUrl.openConnection().getLastModified();
-            return Long.toHexString(lastModified);
+            return Long.toString(resourceUrl.openConnection().getLastModified());
         } catch (IOException e) {
             throw new PippoRuntimeException("Failed to read lastModified property for {}", e, resourceUrl);
         }

--- a/pippo-core/src/main/java/ro/pippo/core/route/UrlResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/UrlResourceHandler.java
@@ -54,12 +54,16 @@ public abstract class UrlResourceHandler extends ResourceHandler {
     public abstract URL getResourceUrl(String resourcePath);
 
     protected String getResourceVersion(String resourcePath) {
+        String version = null;
+
         URL resourceUrl = getResourceUrl(resourcePath);
         try {
-            return Long.toString(resourceUrl.openConnection().getLastModified());
+            version =  Long.toString(resourceUrl.openConnection().getLastModified());
         } catch (IOException e) {
-            throw new PippoRuntimeException("Failed to read lastModified property for {}", e, resourceUrl);
+            log.error("Failed to read lastModified property for {}", resourceUrl, e);
         }
+
+        return version;
     }
 
     @Override

--- a/pippo-core/src/main/java/ro/pippo/core/route/UrlResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/UrlResourceHandler.java
@@ -43,12 +43,6 @@ public abstract class UrlResourceHandler extends ResourceHandler {
 
     @Override
     public final void handleResource(String resourcePath, RouteContext routeContext) {
-        String unversionedResourcePath = removeVersion(resourcePath);
-        if (!unversionedResourcePath.equals(resourcePath)) {
-            log.trace("Remove version from resource path: '{}' => '{}'", resourcePath, unversionedResourcePath);
-            resourcePath = unversionedResourcePath;
-        }
-
         URL url = getResourceUrl(resourcePath);
         if (url == null) {
             routeContext.getResponse().notFound().commit();
@@ -69,9 +63,7 @@ public abstract class UrlResourceHandler extends ResourceHandler {
         }
     }
 
-    /**
-     * Inject version fragment.
-     */
+    @Override
     public String injectVersion(String resourcePath) {
         String version = getResourceVersion(resourcePath);
         if (StringUtils.isNullOrEmpty(version)) {
@@ -98,9 +90,7 @@ public abstract class UrlResourceHandler extends ResourceHandler {
         return versionedResourcePath.toString();
     }
 
-    /**
-     * Remove version fragment.
-     */
+    @Override
     public String removeVersion(String resourcePath) {
         Matcher matcher = VERSION_PATTERN.matcher(resourcePath);
         if (matcher.find()) {

--- a/pippo-core/src/main/java/ro/pippo/core/route/WebjarsResourceHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/WebjarsResourceHandler.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.PippoRuntimeException;
 import ro.pippo.core.util.ClasspathUtils;
+import ro.pippo.core.util.CryptoUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -54,6 +55,24 @@ public class WebjarsResourceHandler extends ClasspathResourceHandler {
         super(urlPath, "META-INF/resources/webjars");
         this.pathAliases = indexWebjars();
     }
+
+    @Override
+    protected String getResourceVersion(String resourcePath) {
+        String artifactPath = resourcePath.substring(0, resourcePath.indexOf('/') + 1);
+        if (pathAliases.containsKey(artifactPath)) {
+            String artifactVersion = pathAliases.get(artifactPath);
+
+            // Do not replace already fixed-version paths.
+            // i.e. skip replacing first path segment of "/jquery/1.11.1/jquery.min.js"
+            // BUT do replace first path segment of "jquery/jquery.min.js".
+            if (!resourcePath.startsWith(artifactVersion)) {
+                return CryptoUtils.getHashMD5(artifactVersion);
+            }
+        }
+
+        return null;
+    }
+
 
     @Override
     public URL getResourceUrl(String resourcePath) {


### PR DESCRIPTION
I propose you an implementation for #228. My intention was to find a simple solution with minimal modifications of the existing code.
Also I wished a solution that is independent by chosen template engine.
The current implementation uses lastModified property. For the moment all static resources are versionable.

Show me the code :)

Template: `hello.peb`
```html
<head>
    <link href="{{ publicAt('css/style.css') }}" rel="stylesheet">
</head>
```

Rendered html:
```html
<head>
    <link href="/public/css/style-1448911263314.css" rel="stylesheet">
</head>
```

Pippo debug console:
```
21:20:36 [qtp1963387170-13] DEBUG ro.pippo.core.util.ClasspathUtils - Located 'templates/hello.peb' in the context classpath
21:20:36 [qtp1963387170-13] DEBUG ro.pippo.core.route.DefaultRouter - Inject version in resource path: 'css/style.css' => 'css/style-1448911218869.css'
21:20:36 [qtp1963387170-13] DEBUG ro.pippo.core.route.RouteDispatcher - Returned status code 200 for GET '/template'
21:20:36 [qtp1963387170-15] DEBUG ro.pippo.core.PippoFilter - Request GET '/public/css/style-1448911218869.css'
21:20:36 [qtp1963387170-15] DEBUG ro.pippo.core.route.DefaultRouter - Found 1 route matches for GET '/public/css/style-1448911218869.css'
21:20:36 [qtp1963387170-15] DEBUG ro.pippo.core.route.DefaultRouteContext - Executing handler for GET '/public/{path: .*}'
21:20:36 [qtp1963387170-15] DEBUG ro.pippo.core.route.UrlResourceHandler - Remove version from resource path: 'css/style-1448911218869.css' => 'css/style.css'
21:20:36 [qtp1963387170-15] DEBUG ro.pippo.core.route.UrlResourceHandler - Streaming as resource 'file:/C:/Users/decebal/work/myproject/target/classes/public/css/style.css'
21:20:36 [qtp1963387170-15] DEBUG ro.pippo.core.route.RouteDispatcher - Returned status code 200 for GET '/public/css/style-1448911218869.css'
21:21:10 [qtp1963387170-16] DEBUG ro.pippo.core.PippoFilter - Request GET '/template'
21:21:10 [qtp1963387170-16] DEBUG ro.pippo.core.route.DefaultRouter - Found 1 route matches for GET '/template'
21:21:10 [qtp1963387170-16] DEBUG ro.pippo.core.route.DefaultRouteContext - Executing handler for GET '/template'
21:21:10 [qtp1963387170-16] DEBUG ro.pippo.core.util.ClasspathUtils - Located 'templates/hello.peb' in the context classpath
21:21:10 [qtp1963387170-16] DEBUG ro.pippo.core.route.DefaultRouter - Inject version in resource path: 'css/style.css' => 'css/style-1448911263314.css'
21:21:10 [qtp1963387170-16] DEBUG ro.pippo.core.route.RouteDispatcher - Returned status code 200 for GET '/template'
21:21:10 [qtp1963387170-19] DEBUG ro.pippo.core.PippoFilter - Request GET '/public/css/style-1448911263314.css'
21:21:10 [qtp1963387170-19] DEBUG ro.pippo.core.route.DefaultRouter - Found 1 route matches for GET '/public/css/style-1448911263314.css'
21:21:10 [qtp1963387170-19] DEBUG ro.pippo.core.route.DefaultRouteContext - Executing handler for GET '/public/{path: .*}'
21:21:10 [qtp1963387170-19] DEBUG ro.pippo.core.route.UrlResourceHandler - Remove version from resource path: 'css/style-1448911263314.css' => 'css/style.css'
21:21:10 [qtp1963387170-19] DEBUG ro.pippo.core.route.UrlResourceHandler - Streaming as resource 'file:/C:/Users/decebal/work/myproject/target/classes/public/css/style.css'
21:21:10 [qtp1963387170-19] DEBUG ro.pippo.core.route.RouteDispatcher - Returned status code 200 for GET '/public/css/style-1448911263314.css'
```

So, the implementation works but probably we should make some small adjustments (better performance maybe ?!).

Ideas for this feature:
- disable versioning
- select a different strategy (the current strategy is based on lastModified property)