### PR TITLE
Add PippoTest

### DIFF
--- a/pippo-test/pom.xml
+++ b/pippo-test/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>ro.pippo</groupId>
+        <artifactId>pippo-parent</artifactId>
+        <version>0.8.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <artifactId>pippo-test</artifactId>
+    <version>0.8.0-SNAPSHOT</version>
+    <name>Pippo Test</name>
+    <description>Base for testing Pippo applications</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ro.pippo</groupId>
+            <artifactId>pippo-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Enforce compile scope on these dependencies -->
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>2.7.0</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pippo-test/src/main/java/ro/pippo/test/PippoTest.java
+++ b/pippo-test/src/main/java/ro/pippo/test/PippoTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.test;
+
+import com.jayway.restassured.RestAssured;
+import org.junit.After;
+import org.junit.Before;
+import ro.pippo.core.Application;
+import ro.pippo.core.Pippo;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+/**
+ * Pippo Test marries Pippo, JUnit and RestAssured to provide a convenient
+ * way to perform integration tests of your Pippo application.
+ * <p>
+ * PippoTest will start your Pippo application on a dynamically assigned port
+ * in TEST mode for execution of your unit tests.
+ * </p>
+ *
+ * @author Decebal Suiu
+ */
+public abstract class PippoTest extends RestAssured {
+
+    private Pippo pippo;
+
+    @Before
+    public void setUp() {
+        startPippo();
+    }
+
+    @After
+    public void tearDown() {
+        stopPippo();
+    }
+
+    public abstract Application createApplication();
+
+    protected Pippo createPippo() {
+        Application application = createApplication();
+        // TODO how can I set the TEST mode?
+
+        return new Pippo(application);
+    }
+
+    protected final Pippo getPippo() {
+        if (pippo == null) {
+            pippo = createPippo();
+
+            // set server port;
+            // the port numbers in the range from 0 to 1023 are the well-known ports or system ports
+            int port = findAvailablePort(1024, 10000);
+            pippo.getServer().getSettings().port(port);
+        }
+
+        return pippo;
+    }
+
+    protected void startPippo() {
+        getPippo().start();
+
+        // init RestAssured
+        RestAssured.port = getPippo().getServer().getSettings().getPort();
+    }
+
+    protected void stopPippo() {
+        // TODO fix the bug in pippo-core (a starting flag maybe)
+        // it's not needed because we have an hook on shutdown
+//        getPippo().stop();
+
+        pippo = null;
+    }
+
+    protected final int findAvailablePort(int min, int max) {
+        for (int port = min; port < max; port++) {
+            try {
+                new ServerSocket(port).close();
+                return port;
+            } catch (IOException e) {
+                // must already be taken
+            }
+        }
+
+        throw new IllegalStateException("Could not find available port in range " + min + " to " + max);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,7 @@
 		<module>pippo-velocity</module>
         <module>pippo-less4j</module>
         <module>pippo-sasscompiler</module>
+        <module>pippo-test</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
Add the possibility for an easy testing. 
Add `PippoTest` class in a new module `pippo-test`, with a simple API, based on rest-assured [1].
I took a look on fathom-test-tools.

How to use:

1. Add the dependency to `pippo-test` in your `pom.xml`
```
<dependency>
    <groupId>ro.pippo</groupId>
    <artifactId>pippo-test</artifactId>
    <version>${pippo.version}</version>
    <scope>test</scope>
</dependency>
```

2. Add a test in your application
```java
public class RoutesTest extends PippoTest {

    @Override
    public Application createApplication() {
        return new MyApplication();
    }

    @Test
    public void testIndex() {
        when().
            get("/").
        then().
            statusCode(200);
    }

}
```

In the current implementation, `PippoTest` creates a new `Pippo` instance for each Test. Sure, another option is to create a `Pippo` instance for all tests but I prefer to "push" this functionality in the actual class (maybe with a flag in `setUp` method that tell me if the instances was already created - I don't know if it's possible or if it's safe) and not to enter a new class with `@BeforeClass` and `@AfterClass`.

This is only a draft and I invite you at discussion.

[1] https://github.com/jayway/rest-assured