### PR TITLE
Transparently support Java 8 -parameters names for controllers

### DIFF
--- a/pippo-controller/src/main/java/ro/pippo/controller/DefaultControllerHandler.java
+++ b/pippo-controller/src/main/java/ro/pippo/controller/DefaultControllerHandler.java
@@ -27,10 +27,12 @@ import ro.pippo.core.util.StringUtils;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -207,11 +209,11 @@ public class DefaultControllerHandler implements ControllerHandler {
     protected String getParameterName(Method method, int i) {
         Annotation annotation = getAnnotation(method, i, Param.class);
         if (annotation != null) {
-            Param parameter = (Param) annotation;
-            return parameter.value();
+            Param param = (Param) annotation;
+            return param.value();
         }
 
-        return null;
+        return Optional.of(method.getParameters()[i]).filter(Parameter::isNamePresent).map(Parameter::getName).get();
     }
 
     protected Class<?> getParameterGenericType(Method method, int i) {


### PR DESCRIPTION
We've discussed this a couple times.  Now that we are on Java 8 this is a no-brainer.

This change allows you to define a controller method like this:

```java
public class ContactsController extends Controller {
    public void uriFor(int id) {
    }
}
```

instead of like this:

```java
public class ContactsController extends Controller {
    public void uriFor(@Param("id") int id) {
    }
}
```

Of course, to have the name automatically embedded in your code **requires** modifying your project compiler flags to specify `-parameters` to javac.  Your IDE needs this specified also, separately AFAICT.

```xml
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-compiler-plugin</artifactId>
    <version>3.1</version>
    <configuration>
        <source>1.8</source>
        <target>1.8</target>
        <compilerArguments>
            <parameters/>
        </compilerArguments>
    </configuration>
</plugin>
```

If you do not compile with this flag then `isNamePresent` will return false and the method will return `null`, just like before.  Which means this change works transparently.