### PR TITLE
Stop manually maintaining pippo-pebble META-INF/services files

### DIFF
--- a/pippo-pebble/pom.xml
+++ b/pippo-pebble/pom.xml
@@ -40,5 +40,11 @@
 			<artifactId>prettytime</artifactId>
 		</dependency>
 
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
 	</dependencies>
 </project>

--- a/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleInitializer.java
+++ b/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.pebble;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ import ro.pippo.core.Initializer;
 /**
  * @author James Moger
  */
+@MetaInfServices(Initializer.class)
 public class PebbleInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(PebbleInitializer.class);

--- a/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
+++ b/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
@@ -21,6 +21,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import com.mitchellbosecke.pebble.loader.StringLoader;
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,7 @@ import com.mitchellbosecke.pebble.template.PebbleTemplate;
  *
  * @author James Moger
  */
+@MetaInfServices(TemplateEngine.class)
 public class PebbleTemplateEngine implements TemplateEngine {
 
     private final Logger log = LoggerFactory.getLogger(PebbleTemplateEngine.class);

--- a/pippo-pebble/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-pebble/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.pebble.PebbleInitializer

--- a/pippo-pebble/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
+++ b/pippo-pebble/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
@@ -1,1 +1,0 @@
-ro.pippo.pebble.PebbleTemplateEngine

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,11 @@
                 <artifactId>prettytime</artifactId>
                 <version>3.2.5.Final</version>
             </dependency>
+            <dependency>
+                <groupId>org.kohsuke.metainf-services</groupId>
+                <artifactId>metainf-services</artifactId>
+                <version>1.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
I discovered this [slick little APT compiler](http://metainf-services.kohsuke.org) which would get us out of the business of manually maintaining `META-INF/services/` files.

Interested?