### PR TITLE
Stop manually maintaining all META-INF/services files

### DIFF
--- a/pippo-csv/pom.xml
+++ b/pippo-csv/pom.xml
@@ -28,6 +28,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/pippo-csv/src/main/java/ro/pippo/csv/CsvEngine.java
+++ b/pippo-csv/src/main/java/ro/pippo/csv/CsvEngine.java
@@ -16,6 +16,7 @@
 package ro.pippo.csv;
 
 import org.apache.commons.csv.*;
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.Application;
@@ -35,6 +36,7 @@ import java.util.*;
 /**
  * @author James Moger
  */
+@MetaInfServices(ContentTypeEngine.class)
 public class CsvEngine implements ContentTypeEngine {
 
     public final static String TEXT_CSV = "text/csv";

--- a/pippo-csv/src/main/java/ro/pippo/csv/CsvInitializer.java
+++ b/pippo-csv/src/main/java/ro/pippo/csv/CsvInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.csv;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.Application;
@@ -23,6 +24,7 @@ import ro.pippo.core.Initializer;
 /**
  * @author James Moger
  */
+@MetaInfServices(Initializer.class)
 public class CsvInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(CsvInitializer.class);

--- a/pippo-csv/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
+++ b/pippo-csv/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
@@ -1,2 +1,0 @@
-ro.pippo.csv.CsvEngine
-

--- a/pippo-csv/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-csv/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.csv.CsvInitializer

--- a/pippo-fastjson/pom.xml
+++ b/pippo-fastjson/pom.xml
@@ -33,6 +33,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/pippo-fastjson/src/main/java/ro/pippo/fastjson/FastjsonEngine.java
+++ b/pippo-fastjson/src/main/java/ro/pippo/fastjson/FastjsonEngine.java
@@ -16,6 +16,7 @@
 package ro.pippo.fastjson;
 
 import com.alibaba.fastjson.serializer.SerializerFeature;
+import org.kohsuke.MetaInfServices;
 import ro.pippo.core.Application;
 import ro.pippo.core.ContentTypeEngine;
 import ro.pippo.core.HttpConstants;
@@ -27,6 +28,7 @@ import com.alibaba.fastjson.JSON;
  *
  * @author James Moger
  */
+@MetaInfServices(ContentTypeEngine.class)
 public class FastjsonEngine implements ContentTypeEngine {
 
 	@Override

--- a/pippo-fastjson/src/main/java/ro/pippo/fastjson/FastjsonInitializer.java
+++ b/pippo-fastjson/src/main/java/ro/pippo/fastjson/FastjsonInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.fastjson;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ import ro.pippo.core.Initializer;
 /**
  * @author James Moger
  */
+@MetaInfServices(Initializer.class)
 public class FastjsonInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(FastjsonInitializer.class);

--- a/pippo-fastjson/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
+++ b/pippo-fastjson/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
@@ -1,1 +1,0 @@
-ro.pippo.fastjson.FastjsonEngine

--- a/pippo-fastjson/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-fastjson/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.fastjson.FastjsonInitializer

--- a/pippo-freemarker/pom.xml
+++ b/pippo-freemarker/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>prettytime</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pippo-freemarker/src/main/java/ro/pippo/freemarker/FreemarkerInitializer.java
+++ b/pippo-freemarker/src/main/java/ro/pippo/freemarker/FreemarkerInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.freemarker;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ import ro.pippo.core.Initializer;
 /**
  * @author Decebal Suiu
  */
+@MetaInfServices(Initializer.class)
 public class FreemarkerInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(FreemarkerInitializer.class);

--- a/pippo-freemarker/src/main/java/ro/pippo/freemarker/FreemarkerTemplateEngine.java
+++ b/pippo-freemarker/src/main/java/ro/pippo/freemarker/FreemarkerTemplateEngine.java
@@ -19,6 +19,7 @@ import java.io.Writer;
 import java.util.Locale;
 import java.util.Map;
 
+import org.kohsuke.MetaInfServices;
 import ro.pippo.core.Application;
 import ro.pippo.core.Languages;
 import ro.pippo.core.Messages;
@@ -36,6 +37,7 @@ import freemarker.template.Template;
 /**
  * @author Decebal Suiu
  */
+@MetaInfServices(TemplateEngine.class)
 public class FreemarkerTemplateEngine implements TemplateEngine {
 
     public static final String FTL = "ftl";

--- a/pippo-freemarker/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-freemarker/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.freemarker.FreemarkerInitializer

--- a/pippo-freemarker/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
+++ b/pippo-freemarker/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
@@ -1,1 +1,0 @@
-ro.pippo.freemarker.FreemarkerTemplateEngine

--- a/pippo-groovy/pom.xml
+++ b/pippo-groovy/pom.xml
@@ -39,5 +39,11 @@
 			<artifactId>prettytime</artifactId>
 		</dependency>
 
-	</dependencies>
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
 </project>

--- a/pippo-groovy/src/main/java/ro/pippo/groovy/GroovyInitializer.java
+++ b/pippo-groovy/src/main/java/ro/pippo/groovy/GroovyInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.groovy;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ import ro.pippo.core.Initializer;
 /**
  * @author James Moger
  */
+@MetaInfServices(Initializer.class)
 public class GroovyInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(GroovyInitializer.class);

--- a/pippo-groovy/src/main/java/ro/pippo/groovy/GroovyTemplateEngine.java
+++ b/pippo-groovy/src/main/java/ro/pippo/groovy/GroovyTemplateEngine.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Map;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +42,7 @@ import ro.pippo.core.util.StringUtils;
  *
  * @author James Moger
  */
+@MetaInfServices(TemplateEngine.class)
 public class GroovyTemplateEngine implements TemplateEngine {
 
     private static final Logger log = LoggerFactory.getLogger(GroovyTemplateEngine.class);

--- a/pippo-groovy/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-groovy/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.groovy.GroovyInitializer

--- a/pippo-groovy/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
+++ b/pippo-groovy/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
@@ -1,1 +1,0 @@
-ro.pippo.groovy.GroovyTemplateEngine

--- a/pippo-gson/pom.xml
+++ b/pippo-gson/pom.xml
@@ -33,6 +33,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/pippo-gson/src/main/java/ro/pippo/gson/GsonEngine.java
+++ b/pippo-gson/src/main/java/ro/pippo/gson/GsonEngine.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSyntaxException;
+import org.kohsuke.MetaInfServices;
 import ro.pippo.core.Application;
 import ro.pippo.core.ContentTypeEngine;
 import ro.pippo.core.HttpConstants;
@@ -41,6 +42,7 @@ import java.util.Locale;
  *
  * @author James Moger
  */
+@MetaInfServices(ContentTypeEngine.class)
 public class GsonEngine implements ContentTypeEngine {
 
     @Override

--- a/pippo-gson/src/main/java/ro/pippo/gson/GsonInitializer.java
+++ b/pippo-gson/src/main/java/ro/pippo/gson/GsonInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.gson;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ import ro.pippo.core.Initializer;
 /**
  * @author James Moger
  */
+@MetaInfServices(Initializer.class)
 public class GsonInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(GsonInitializer.class);

--- a/pippo-gson/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
+++ b/pippo-gson/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
@@ -1,1 +1,0 @@
-ro.pippo.gson.GsonEngine

--- a/pippo-gson/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-gson/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.gson.GsonInitializer

--- a/pippo-jackson/pom.xml
+++ b/pippo-jackson/pom.xml
@@ -31,23 +31,33 @@
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
             <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonInitializer.java
+++ b/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.jackson;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.Application;
@@ -24,6 +25,7 @@ import ro.pippo.core.util.ClasspathUtils;
 /**
  * @author James Moger
  */
+@MetaInfServices(Initializer.class)
 public class JacksonInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(JacksonInitializer.class);

--- a/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonJsonEngine.java
+++ b/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonJsonEngine.java
@@ -16,6 +16,8 @@
 package ro.pippo.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.kohsuke.MetaInfServices;
+import ro.pippo.core.ContentTypeEngine;
 import ro.pippo.core.HttpConstants;
 
 /**
@@ -23,6 +25,7 @@ import ro.pippo.core.HttpConstants;
  *
  * @author James Moger
  */
+@MetaInfServices(ContentTypeEngine.class)
 public class JacksonJsonEngine extends JacksonBaseEngine {
 
     @Override

--- a/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonXmlEngine.java
+++ b/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonXmlEngine.java
@@ -18,6 +18,8 @@ package ro.pippo.jackson;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.kohsuke.MetaInfServices;
+import ro.pippo.core.ContentTypeEngine;
 import ro.pippo.core.HttpConstants;
 
 /**
@@ -25,6 +27,7 @@ import ro.pippo.core.HttpConstants;
  *
  * @author James Moger
  */
+@MetaInfServices(ContentTypeEngine.class)
 public class JacksonXmlEngine extends JacksonBaseEngine {
 
     @Override

--- a/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonYamlEngine.java
+++ b/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonYamlEngine.java
@@ -17,6 +17,8 @@ package ro.pippo.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import org.kohsuke.MetaInfServices;
+import ro.pippo.core.ContentTypeEngine;
 import ro.pippo.core.HttpConstants;
 
 /**
@@ -24,6 +26,7 @@ import ro.pippo.core.HttpConstants;
  *
  * @author James Moger
  */
+@MetaInfServices(ContentTypeEngine.class)
 public class JacksonYamlEngine extends JacksonBaseEngine {
 
     @Override

--- a/pippo-jackson/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
+++ b/pippo-jackson/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
@@ -1,3 +1,0 @@
-ro.pippo.jackson.JacksonJsonEngine
-ro.pippo.jackson.JacksonXmlEngine
-ro.pippo.jackson.JacksonYamlEngine

--- a/pippo-jackson/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-jackson/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.jackson.JacksonInitializer

--- a/pippo-jade/pom.xml
+++ b/pippo-jade/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>prettytime</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pippo-jade/src/main/java/ro/pippo/jade/JadeInitializer.java
+++ b/pippo-jade/src/main/java/ro/pippo/jade/JadeInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.jade;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ import ro.pippo.core.Initializer;
 /**
  * @author Decebal Suiu
  */
+@MetaInfServices(Initializer.class)
 public class JadeInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(JadeInitializer.class);

--- a/pippo-jade/src/main/java/ro/pippo/jade/JadeTemplateEngine.java
+++ b/pippo-jade/src/main/java/ro/pippo/jade/JadeTemplateEngine.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import de.neuland.jade4j.template.ReaderTemplateLoader;
+import org.kohsuke.MetaInfServices;
 import ro.pippo.core.Application;
 import ro.pippo.core.Languages;
 import ro.pippo.core.Messages;
@@ -41,6 +42,7 @@ import de.neuland.jade4j.template.TemplateLoader;
 /**
  * @author Decebal Suiu
  */
+@MetaInfServices(TemplateEngine.class)
 public class JadeTemplateEngine implements TemplateEngine {
 
     private Languages languages;

--- a/pippo-jade/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-jade/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.jade.JadeInitializer

--- a/pippo-jade/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
+++ b/pippo-jade/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
@@ -1,1 +1,0 @@
-ro.pippo.jade.JadeTemplateEngine

--- a/pippo-jaxb/pom.xml
+++ b/pippo-jaxb/pom.xml
@@ -15,11 +15,19 @@
     <description>JAXB integration</description>
 
     <dependencies>
+
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pippo-jaxb/src/main/java/ro/pippo/jaxb/JaxbEngine.java
+++ b/pippo-jaxb/src/main/java/ro/pippo/jaxb/JaxbEngine.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.jaxb;
 
+import org.kohsuke.MetaInfServices;
 import ro.pippo.core.Application;
 import ro.pippo.core.ContentTypeEngine;
 import ro.pippo.core.HttpConstants;
@@ -32,6 +33,7 @@ import java.io.StringWriter;
  *
  * @author James Moger
  */
+@MetaInfServices(ContentTypeEngine.class)
 public class JaxbEngine implements ContentTypeEngine {
 
     boolean prettyPrint;

--- a/pippo-jaxb/src/main/java/ro/pippo/jaxb/JaxbInitializer.java
+++ b/pippo-jaxb/src/main/java/ro/pippo/jaxb/JaxbInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.jaxb;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.Application;
@@ -23,6 +24,7 @@ import ro.pippo.core.Initializer;
 /**
  * @author James Moger
  */
+@MetaInfServices(Initializer.class)
 public class JaxbInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(JaxbInitializer.class);

--- a/pippo-jaxb/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
+++ b/pippo-jaxb/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
@@ -1,1 +1,0 @@
-ro.pippo.jaxb.JaxbEngine

--- a/pippo-jaxb/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-jaxb/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.jaxb.JaxbInitializer

--- a/pippo-jetty/pom.xml
+++ b/pippo-jetty/pom.xml
@@ -42,6 +42,13 @@
             <artifactId>jetty-annotations</artifactId>
             <version>${jetty.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pippo-jetty/src/main/java/ro/pippo/jetty/JettyServer.java
+++ b/pippo-jetty/src/main/java/ro/pippo/jetty/JettyServer.java
@@ -23,11 +23,13 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.AbstractWebServer;
 import ro.pippo.core.HttpConstants;
 import ro.pippo.core.PippoRuntimeException;
+import ro.pippo.core.WebServer;
 
 import javax.servlet.DispatcherType;
 import javax.servlet.MultipartConfigElement;
@@ -41,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * @author Decebal Suiu
  */
+@MetaInfServices(WebServer.class)
 public class JettyServer extends AbstractWebServer<JettySettings> {
 
     private static final Logger log = LoggerFactory.getLogger(JettyServer.class);

--- a/pippo-jetty/src/main/resources/META-INF/services/ro.pippo.core.WebServer
+++ b/pippo-jetty/src/main/resources/META-INF/services/ro.pippo.core.WebServer
@@ -1,1 +1,0 @@
-ro.pippo.jetty.JettyServer

--- a/pippo-metrics-ganglia/pom.xml
+++ b/pippo-metrics-ganglia/pom.xml
@@ -33,5 +33,12 @@
 			<artifactId>metrics-ganglia</artifactId>
 			<version>${metrics.version}</version>
 		</dependency>
-	</dependencies>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
 </project>

--- a/pippo-metrics-ganglia/src/main/java/ro/pippo/ganglia/Reporter.java
+++ b/pippo-metrics-ganglia/src/main/java/ro/pippo/ganglia/Reporter.java
@@ -21,6 +21,7 @@ import info.ganglia.gmetric4j.gmetric.GMetric.UDPAddressingMode;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +37,7 @@ import com.codahale.metrics.ganglia.GangliaReporter;
  * @author James Moger
  *
  */
+@MetaInfServices(MetricsReporter.class)
 public class Reporter implements MetricsReporter {
 
 	private final Logger log = LoggerFactory.getLogger(Reporter.class);

--- a/pippo-metrics-ganglia/src/main/resources/META-INF/services/ro.pippo.metrics.MetricsReporter
+++ b/pippo-metrics-ganglia/src/main/resources/META-INF/services/ro.pippo.metrics.MetricsReporter
@@ -1,1 +1,0 @@
-ro.pippo.ganglia.Reporter

--- a/pippo-metrics-graphite/pom.xml
+++ b/pippo-metrics-graphite/pom.xml
@@ -33,5 +33,12 @@
 			<artifactId>metrics-graphite</artifactId>
 			<version>${metrics.version}</version>
 		</dependency>
-	</dependencies>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
 </project>

--- a/pippo-metrics-graphite/src/main/java/ro/pippo/graphite/Reporter.java
+++ b/pippo-metrics-graphite/src/main/java/ro/pippo/graphite/Reporter.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,7 @@ import com.codahale.metrics.graphite.PickledGraphite;
  * @author James Moger
  *
  */
+@MetaInfServices(MetricsReporter.class)
 public class Reporter implements MetricsReporter {
 
 	private final Logger log = LoggerFactory.getLogger(Reporter.class);

--- a/pippo-metrics-graphite/src/main/resources/META-INF/services/ro.pippo.metrics.MetricsReporter
+++ b/pippo-metrics-graphite/src/main/resources/META-INF/services/ro.pippo.metrics.MetricsReporter
@@ -1,1 +1,0 @@
-ro.pippo.graphite.Reporter

--- a/pippo-metrics-influxdb/pom.xml
+++ b/pippo-metrics-influxdb/pom.xml
@@ -37,5 +37,12 @@
 			<artifactId>metrics-influxdb</artifactId>
 			<version>${influxdb.version}</version>
 		</dependency>
-	</dependencies>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
 </project>

--- a/pippo-metrics-influxdb/src/main/java/ro/pippo/influxdb/Reporter.java
+++ b/pippo-metrics-influxdb/src/main/java/ro/pippo/influxdb/Reporter.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 import metrics_influxdb.InfluxdbHttp;
 import metrics_influxdb.InfluxdbReporter;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +37,7 @@ import com.codahale.metrics.MetricRegistry;
  * @author James Moger
  *
  */
+@MetaInfServices(MetricsReporter.class)
 public class Reporter implements MetricsReporter {
 
 	private final Logger log = LoggerFactory.getLogger(Reporter.class);

--- a/pippo-metrics-influxdb/src/main/resources/META-INF/services/ro.pippo.metrics.MetricsReporter
+++ b/pippo-metrics-influxdb/src/main/resources/META-INF/services/ro.pippo.metrics.MetricsReporter
@@ -1,1 +1,0 @@
-ro.pippo.influxdb.Reporter

--- a/pippo-metrics-librato/pom.xml
+++ b/pippo-metrics-librato/pom.xml
@@ -37,5 +37,12 @@
 			<artifactId>metrics-librato</artifactId>
 			<version>${librato.version}</version>
 		</dependency>
-	</dependencies>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
 </project>

--- a/pippo-metrics-librato/src/main/java/ro/pippo/librato/Reporter.java
+++ b/pippo-metrics-librato/src/main/java/ro/pippo/librato/Reporter.java
@@ -18,6 +18,7 @@ package ro.pippo.librato;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,7 @@ import com.librato.metrics.LibratoReporter;
  * @author James Moger
  *
  */
+@MetaInfServices(MetricsReporter.class)
 public class Reporter implements MetricsReporter {
 
 	private final Logger log = LoggerFactory.getLogger(Reporter.class);

--- a/pippo-metrics-librato/src/main/resources/META-INF/services/ro.pippo.metrics.MetricsReporter
+++ b/pippo-metrics-librato/src/main/resources/META-INF/services/ro.pippo.metrics.MetricsReporter
@@ -1,1 +1,0 @@
-ro.pippo.librato.Reporter

--- a/pippo-metrics/pom.xml
+++ b/pippo-metrics/pom.xml
@@ -39,5 +39,12 @@
             <artifactId>metrics-jvm</artifactId>
             <version>${metrics.version}</version>
         </dependency>
-	</dependencies>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
 </project>

--- a/pippo-metrics/src/main/java/ro/pippo/metrics/PippoMetrics.java
+++ b/pippo-metrics/src/main/java/ro/pippo/metrics/PippoMetrics.java
@@ -23,6 +23,7 @@ import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.Application;
@@ -46,6 +47,7 @@ import java.util.Map;
  *
  * @author James Moger
  */
+@MetaInfServices(RouteContextFactory.class)
 public class PippoMetrics implements RouteContextFactory<MetricsRouteContext> {
 
     private static final Logger log = LoggerFactory.getLogger(PippoMetrics.class);

--- a/pippo-metrics/src/main/resources/META-INF/services/ro.pippo.core.route.RouteContextFactory
+++ b/pippo-metrics/src/main/resources/META-INF/services/ro.pippo.core.route.RouteContextFactory
@@ -1,1 +1,0 @@
-ro.pippo.metrics.PippoMetrics

--- a/pippo-pebble/pom.xml
+++ b/pippo-pebble/pom.xml
@@ -40,5 +40,11 @@
 			<artifactId>prettytime</artifactId>
 		</dependency>
 
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
 	</dependencies>
 </project>

--- a/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleInitializer.java
+++ b/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.pebble;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ import ro.pippo.core.Initializer;
 /**
  * @author James Moger
  */
+@MetaInfServices(Initializer.class)
 public class PebbleInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(PebbleInitializer.class);

--- a/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
+++ b/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
@@ -21,6 +21,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import com.mitchellbosecke.pebble.loader.StringLoader;
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,7 @@ import com.mitchellbosecke.pebble.template.PebbleTemplate;
  *
  * @author James Moger
  */
+@MetaInfServices(TemplateEngine.class)
 public class PebbleTemplateEngine implements TemplateEngine {
 
     private final Logger log = LoggerFactory.getLogger(PebbleTemplateEngine.class);

--- a/pippo-pebble/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-pebble/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.pebble.PebbleInitializer

--- a/pippo-pebble/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
+++ b/pippo-pebble/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
@@ -1,1 +1,0 @@
-ro.pippo.pebble.PebbleTemplateEngine

--- a/pippo-snakeyaml/pom.xml
+++ b/pippo-snakeyaml/pom.xml
@@ -31,6 +31,12 @@
             <version>${snakeyaml.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pippo-snakeyaml/src/main/java/ro/pippo/snakeyaml/SnakeYamlEngine.java
+++ b/pippo-snakeyaml/src/main/java/ro/pippo/snakeyaml/SnakeYamlEngine.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.snakeyaml;
 
+import org.kohsuke.MetaInfServices;
 import org.yaml.snakeyaml.Yaml;
 import ro.pippo.core.Application;
 import ro.pippo.core.ContentTypeEngine;
@@ -25,6 +26,7 @@ import ro.pippo.core.HttpConstants;
  *
  * @author James Moger
  */
+@MetaInfServices(ContentTypeEngine.class)
 public class SnakeYamlEngine implements ContentTypeEngine {
 
     @Override

--- a/pippo-snakeyaml/src/main/java/ro/pippo/snakeyaml/SnakeYamlInitializer.java
+++ b/pippo-snakeyaml/src/main/java/ro/pippo/snakeyaml/SnakeYamlInitializer.java
@@ -15,12 +15,14 @@
  */
 package ro.pippo.snakeyaml;
 
+import org.kohsuke.MetaInfServices;
 import ro.pippo.core.Application;
 import ro.pippo.core.Initializer;
 
 /**
  * @author James Moger
  */
+@MetaInfServices(Initializer.class)
 public class SnakeYamlInitializer implements Initializer {
 
     @Override

--- a/pippo-snakeyaml/src/main/resources/services/ro.pippo.core.ContentTypeEngine
+++ b/pippo-snakeyaml/src/main/resources/services/ro.pippo.core.ContentTypeEngine
@@ -1,1 +1,0 @@
-ro.pippo.snakeyaml.SnakeYamlEngine

--- a/pippo-snakeyaml/src/main/resources/services/ro.pippo.core.Initializer
+++ b/pippo-snakeyaml/src/main/resources/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.snakeyaml.SnakeYamlInitializer

--- a/pippo-tjws/pom.xml
+++ b/pippo-tjws/pom.xml
@@ -24,6 +24,13 @@
             <artifactId>tjws</artifactId>
             <version>3.0.10.Final</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pippo-tjws/src/main/java/ro/pippo/tjws/TjwsServer.java
+++ b/pippo-tjws/src/main/java/ro/pippo/tjws/TjwsServer.java
@@ -16,6 +16,7 @@
 package ro.pippo.tjws;
 
 import Acme.Serve.Serve;
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.AbstractWebServer;
@@ -23,6 +24,7 @@ import ro.pippo.core.Application;
 import ro.pippo.core.PippoFilter;
 import ro.pippo.core.PippoRuntimeException;
 import ro.pippo.core.PippoServlet;
+import ro.pippo.core.WebServer;
 import ro.pippo.core.WebServerSettings;
 
 import java.io.IOException;
@@ -42,6 +44,7 @@ import java.util.Properties;
  *
  * @author James Moger
  */
+@MetaInfServices(WebServer.class)
 public class TjwsServer extends AbstractWebServer<WebServerSettings> {
 
     private static final Logger log = LoggerFactory.getLogger(TjwsServer.class);

--- a/pippo-tjws/src/main/resources/META-INF/services/ro.pippo.core.WebServer
+++ b/pippo-tjws/src/main/resources/META-INF/services/ro.pippo.core.WebServer
@@ -1,1 +1,0 @@
-ro.pippo.tjws.TjwsServer

--- a/pippo-tomcat/pom.xml
+++ b/pippo-tomcat/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>pippo-parent</artifactId>
         <groupId>ro.pippo</groupId>
@@ -11,7 +12,7 @@
     <name>Pippo Tomcat</name>
     <description>Tomcat Embedded Web Server</description>
     <properties>
-	<tomcat.version>8.0.28</tomcat.version>
+        <tomcat.version>8.0.28</tomcat.version>
     </properties>
 
 
@@ -23,35 +24,47 @@
         </dependency>
 
         <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-core</artifactId>
-        <version>${tomcat.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-logging-juli</artifactId>
-        <version>${tomcat.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-jasper</artifactId>
-        <version>${tomcat.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-jasper</artifactId>
-        <version>${tomcat.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-jasper-el</artifactId>
-        <version>${tomcat.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-jsp-api</artifactId>
-        <version>${tomcat.version}</version>
-    </dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-logging-juli</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-jasper</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jasper</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jasper-el</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jsp-api</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pippo-tomcat/src/main/java/ro/pippo/tomcat/TomcatServer.java
+++ b/pippo-tomcat/src/main/java/ro/pippo/tomcat/TomcatServer.java
@@ -20,6 +20,7 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.AbstractWebServer;
@@ -28,6 +29,7 @@ import ro.pippo.core.PippoFilter;
 
 import ro.pippo.core.PippoRuntimeException;
 import ro.pippo.core.PippoServlet;
+import ro.pippo.core.WebServer;
 import ro.pippo.core.util.StringUtils;
 
 import java.io.File;
@@ -35,6 +37,7 @@ import java.io.File;
 /**
  * @author Daniel Jipa
  */
+@MetaInfServices(WebServer.class)
 public class TomcatServer extends AbstractWebServer<TomcatSettings> {
 
     private static final Logger log = LoggerFactory.getLogger(TomcatServer.class);

--- a/pippo-tomcat/src/main/resources/META-INF/services/ro.pippo.core.WebServer
+++ b/pippo-tomcat/src/main/resources/META-INF/services/ro.pippo.core.WebServer
@@ -1,1 +1,0 @@
-ro.pippo.tomcat.TomcatServer

--- a/pippo-trimou/pom.xml
+++ b/pippo-trimou/pom.xml
@@ -51,5 +51,11 @@
 			<version>${trimou.version}</version>
 		</dependency>
 
-	</dependencies>
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
 </project>

--- a/pippo-trimou/src/main/java/ro/pippo/trimou/TrimouInitializer.java
+++ b/pippo-trimou/src/main/java/ro/pippo/trimou/TrimouInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.trimou;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ import ro.pippo.core.Initializer;
 /**
  * @author James Moger
  */
+@MetaInfServices(Initializer.class)
 public class TrimouInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(TrimouInitializer.class);

--- a/pippo-trimou/src/main/java/ro/pippo/trimou/TrimouTemplateEngine.java
+++ b/pippo-trimou/src/main/java/ro/pippo/trimou/TrimouTemplateEngine.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.trimou;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.trimou.Mustache;
@@ -43,6 +44,7 @@ import java.util.Map;
  *
  * @author James Moger
  */
+@MetaInfServices(TemplateEngine.class)
 public class TrimouTemplateEngine implements TemplateEngine {
 
     private static final Logger log = LoggerFactory.getLogger(TrimouTemplateEngine.class);

--- a/pippo-trimou/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-trimou/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.trimou.TrimouInitializer

--- a/pippo-trimou/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
+++ b/pippo-trimou/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
@@ -1,1 +1,0 @@
-ro.pippo.trimou.TrimouTemplateEngine

--- a/pippo-undertow/pom.xml
+++ b/pippo-undertow/pom.xml
@@ -26,6 +26,13 @@
             <artifactId>undertow-servlet</artifactId>
             <version>1.3.16.Final</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pippo-undertow/src/main/java/ro/pippo/undertow/UndertowServer.java
+++ b/pippo-undertow/src/main/java/ro/pippo/undertow/UndertowServer.java
@@ -29,12 +29,14 @@ import io.undertow.servlet.api.FilterInfo;
 import io.undertow.servlet.api.ServletInfo;
 import io.undertow.servlet.handlers.DefaultServlet;
 import io.undertow.servlet.util.ImmediateInstanceFactory;
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.AbstractWebServer;
 import ro.pippo.core.Application;
 import ro.pippo.core.PippoFilter;
 import ro.pippo.core.PippoRuntimeException;
+import ro.pippo.core.WebServer;
 import ro.pippo.core.util.StringUtils;
 
 import javax.net.ssl.KeyManager;
@@ -57,6 +59,7 @@ import java.security.KeyStore;
  *
  * @author James Moger
  */
+@MetaInfServices(WebServer.class)
 public class UndertowServer extends AbstractWebServer<UndertowSettings> {
 
     private static final Logger log = LoggerFactory.getLogger(UndertowServer.class);

--- a/pippo-undertow/src/main/resources/META-INF/services/ro.pippo.core.WebServer
+++ b/pippo-undertow/src/main/resources/META-INF/services/ro.pippo.core.WebServer
@@ -1,1 +1,0 @@
-ro.pippo.undertow.UndertowServer

--- a/pippo-velocity/pom.xml
+++ b/pippo-velocity/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>prettytime</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pippo-velocity/src/main/java/ro/pippo/velocity/VelocityInitializer.java
+++ b/pippo-velocity/src/main/java/ro/pippo/velocity/VelocityInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.velocity;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.Application;
@@ -23,6 +24,7 @@ import ro.pippo.core.Initializer;
 /**
  * @author Decebal Suiu
  */
+@MetaInfServices(Initializer.class)
 public class VelocityInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(VelocityInitializer.class);

--- a/pippo-velocity/src/main/java/ro/pippo/velocity/VelocityTemplateEngine.java
+++ b/pippo-velocity/src/main/java/ro/pippo/velocity/VelocityTemplateEngine.java
@@ -21,6 +21,7 @@ import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeServices;
 import org.apache.velocity.runtime.RuntimeSingleton;
 import org.apache.velocity.runtime.parser.node.SimpleNode;
+import org.kohsuke.MetaInfServices;
 import ro.pippo.core.Application;
 import ro.pippo.core.Languages;
 import ro.pippo.core.Messages;
@@ -40,6 +41,7 @@ import java.util.Properties;
 /**
  * @author Decebal Suiu
  */
+@MetaInfServices(TemplateEngine.class)
 public class VelocityTemplateEngine implements TemplateEngine {
 
     public static final String VM = "vm";

--- a/pippo-velocity/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-velocity/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.velocity.VelocityInitializer

--- a/pippo-velocity/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
+++ b/pippo-velocity/src/main/resources/META-INF/services/ro.pippo.core.TemplateEngine
@@ -1,1 +1,0 @@
-ro.pippo.velocity.VelocityTemplateEngine

--- a/pippo-xstream/pom.xml
+++ b/pippo-xstream/pom.xml
@@ -32,6 +32,12 @@
           <version>${xstream.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pippo-xstream/src/main/java/ro/pippo/xstream/XstreamEngine.java
+++ b/pippo-xstream/src/main/java/ro/pippo/xstream/XstreamEngine.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.xstream;
 
+import org.kohsuke.MetaInfServices;
 import ro.pippo.core.Application;
 import ro.pippo.core.ContentTypeEngine;
 import ro.pippo.core.HttpConstants;
@@ -26,6 +27,7 @@ import com.thoughtworks.xstream.XStream;
  *
  * @author James Moger
  */
+@MetaInfServices(ContentTypeEngine.class)
 public class XstreamEngine implements ContentTypeEngine {
 
 	@Override

--- a/pippo-xstream/src/main/java/ro/pippo/xstream/XstreamInitializer.java
+++ b/pippo-xstream/src/main/java/ro/pippo/xstream/XstreamInitializer.java
@@ -15,6 +15,7 @@
  */
 package ro.pippo.xstream;
 
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ import ro.pippo.core.Initializer;
 /**
  * @author James Moger
  */
+@MetaInfServices(Initializer.class)
 public class XstreamInitializer implements Initializer {
 
     private static final Logger log = LoggerFactory.getLogger(XstreamInitializer.class);

--- a/pippo-xstream/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
+++ b/pippo-xstream/src/main/resources/META-INF/services/ro.pippo.core.ContentTypeEngine
@@ -1,1 +1,0 @@
-ro.pippo.xstream.XstreamEngine

--- a/pippo-xstream/src/main/resources/META-INF/services/ro.pippo.core.Initializer
+++ b/pippo-xstream/src/main/resources/META-INF/services/ro.pippo.core.Initializer
@@ -1,1 +1,0 @@
-ro.pippo.xstream.XstreamInitializer

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,11 @@
                 <artifactId>prettytime</artifactId>
                 <version>3.2.5.Final</version>
             </dependency>
+            <dependency>
+                <groupId>org.kohsuke.metainf-services</groupId>
+                <artifactId>metainf-services</artifactId>
+                <version>1.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
There are two options for how to use this tool:

```java
@MetaInfServices
public class MyEngine implements ContentTypeEngine {
```

and

```java
@MetaInfServices(ContentTypeEngine.class)
public class MyEngine implements ContentTypeEngine {
```

The less verbose style does not work for classes with multiple interfaces or hierarchies.  So this PR currently uses the second more verbose style for everything.

If you wish to use the less verbose style, where possible, I can refine.