### PR TITLE
Setup RestAssurred with ContentTypeEngines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade [pippo-undertow] to Undertow 1.3.16
 - Use `org.kohsuke.metainf-services:meta-services` annotation processor to automatically generate all META-INF/services files
 - [pippo-csv] now properly collects all fields in a class hierarchy when deserializing objects
+- [pippo-test] Automatically initialize RestAssurred with Pippo ContentType engines
 
 #### Added
 


### PR DESCRIPTION
This allows you to re-use the server's content type engines from your restful tests.

```java
Item item = given().accept(JSON).when().get("/api/v1/items/{id}", 1).as(Item.class);
assertEquals("Item id does not match", 1, item.getId());
assertEquals("Item name does not match", "Apples", item.getName());
```