### PR TITLE
a bug when route.uriPattern is "/"

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/route/Route.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Route.java
@@ -131,8 +131,7 @@ public class Route {
                 path = StringUtils.addStart(StringUtils.addStart(path, "/"), group.getUriPattern());
                 group = group.getParent();
             }
-
-            absoluteUriPattern = StringUtils.removeEnd(path, "/");
+            absoluteUriPattern = "/".equals(path) ? path : StringUtils.removeEnd(path, "/");
         }
 
         return absoluteUriPattern;


### PR DESCRIPTION
when uriPattern is “/”, it will be format to an empty string, 