### PR TITLE
use Java7 Regex Named Groups fixed PathRegexBuilder wrong pathParameter bug

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -53,7 +53,7 @@ public class DefaultRouter implements Router {
     private static final Pattern PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE = Pattern.compile("\\{(.*?)(:\\s(.*?))?\\}");
 
     // This regex matches everything in between path slashes.
-    private static final String VARIABLE_ROUTES_DEFAULT_REGEX = "([^/]*)";
+    private static final String VARIABLE_ROUTES_DEFAULT_REGEX = "(?<%s>[^/]*)";
 
     // This regex works for both {myParam} AND {myParam: .*}
     private static final String VARIABLE_PART_PATTERN_WITH_PLACEHOLDER = "\\{(%s)(:\\s([^}]*))?\\}";
@@ -339,16 +339,17 @@ public class DefaultRouter implements Router {
         while (matcher.find()) {
             // By convention group 3 is the regex if provided by the user.
             // If it is not provided by the user the group 3 is null.
+            String variablePartOfRouteName = matcher.group(1);
             String namedVariablePartOfRoute = matcher.group(3);
             String namedVariablePartOfORouteReplacedWithRegex;
 
             if (namedVariablePartOfRoute != null) {
                 // we convert that into a regex matcher group itself
                 String variableRegex = replacePosixClasses(namedVariablePartOfRoute);
-                namedVariablePartOfORouteReplacedWithRegex = "(" + Matcher.quoteReplacement(variableRegex) + ")";
+                namedVariablePartOfORouteReplacedWithRegex = String.format("(?<%s>%s)", variablePartOfRouteName, Matcher.quoteReplacement(variableRegex));
             } else {
                 // we convert that into the default namedVariablePartOfRoute regex group
-                namedVariablePartOfORouteReplacedWithRegex = VARIABLE_ROUTES_DEFAULT_REGEX;
+                namedVariablePartOfORouteReplacedWithRegex = String.format(VARIABLE_ROUTES_DEFAULT_REGEX, variablePartOfRouteName);
             }
             // we replace the current namedVariablePartOfRoute group
             matcher.appendReplacement(buffer, namedVariablePartOfORouteReplacedWithRegex);
@@ -410,8 +411,8 @@ public class DefaultRouter implements Router {
         matcher.matches();
         int groupCount = matcher.groupCount();
         if (groupCount > 0) {
-            for (int i = 0; i < parameterNames.size(); i++) {
-                parameters.put(parameterNames.get(i), matcher.group(i + 1));
+            for (String name : parameterNames) {
+                parameters.put(name, matcher.group(name));
             }
         }
 

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -53,7 +53,7 @@ public class DefaultRouter implements Router {
     private static final Pattern PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE = Pattern.compile("\\{(.*?)(:\\s(.*?))?\\}");
 
     // This regex matches everything in between path slashes.
-    private static final String VARIABLE_ROUTES_DEFAULT_REGEX = "(?<%s>[^/]*)";
+    private static final String VARIABLE_ROUTES_DEFAULT_REGEX = "(?<%s>[^/]+)";
 
     // This regex works for both {myParam} AND {myParam: .*}
     private static final String VARIABLE_PART_PATTERN_WITH_PLACEHOLDER = "\\{(%s)(:\\s([^}]*))?\\}";

--- a/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
@@ -718,6 +718,15 @@ public class DefaultRouterTest {
         assertEquals(1, matches.size());
     }
 
+    @Test
+    public void testEmptyStringAsPathParameter() {
+        router.addRoute(Route.GET("/", emptyRouteHandler));
+        router.addRoute(Route.GET("/{id}", emptyRouteHandler));
+
+        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/");
+        assertEquals(1, matches.size());
+    }
+
     private class UserGroup extends RouteGroup {
 
         public UserGroup() {

--- a/pippo-core/src/test/java/ro/pippo/core/PathRegexBuilderTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/PathRegexBuilderTest.java
@@ -15,7 +15,15 @@
  */
 package ro.pippo.core;
 
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import ro.pippo.core.route.DefaultRouter;
+import ro.pippo.core.route.Route;
+import ro.pippo.core.route.RouteHandler;
+import ro.pippo.core.route.RouteMatch;
+import ro.pippo.core.route.Router;
 import ro.pippo.core.util.PathRegexBuilder;
 
 import java.util.regex.Matcher;
@@ -27,6 +35,15 @@ import static org.junit.Assert.*;
  * @author Decebal Suiu
  */
 public class PathRegexBuilderTest {
+
+    private static final RouteHandler emptyRouteHandler = new EmptyRouteHandler();
+
+    private DefaultRouter router;
+
+    @Before
+    public void before() {
+        router = new DefaultRouter();
+    }
 
     @Test
     public void testBuild() throws Exception {
@@ -46,5 +63,23 @@ public class PathRegexBuilderTest {
         Matcher matcher = Pattern.compile(regex).matcher(test);
         assertTrue(matcher.matches());
     }
+
+    @Test
+    public void testAnt() throws Exception {
+        String test = "/aaa";
+
+        String regex = new PathRegexBuilder()
+            .includes(
+                "/{id}"
+            )
+            .excludes(
+                "/admin"
+            )
+            .build();
+
+        router.addRoute(Route.GET(regex, emptyRouteHandler));
+        assertEquals("aaa", router.findRoutes("GET", test).get(0).getPathParameters().get("id"));
+    }
+
 
 }


### PR DESCRIPTION
> I have actually gotten this to work properly now.

> I had already thought of adding a /user part to the URL but I really like the /{username} URL so I wanted to try to make that work first.

> I have also tried to exclude certain routes like /login using a PathRegexBuilder. This works but there is a bug in getting the path parameter.

> Let's say I go to the route "/Username". When I try to get the username path parameter using getPathParameter("username") it should give me the value "Username", right? Instead it gives me the value "/Username" (note that the forwardslash is included in the value). 

> I have fixed this by using the String.replace function, but this is essentially a bug I think. It only happens when I use the PathRegexBuilder.

from [google group][1]

i tried pippo `0.8.0` and `0.9.0-SNAPSHOT`, it really happened, because the regex from `PathRegexBuilder.build` had extra groups, then `matcher.group(index)` get wrong group.

like:

```
// new PathRegexBuilder().includes("/{username}").excludes("/login").build();
("/aaa" =~ /(?=^(\/([^\/]*)).*)^(?!\/login).+/).each { x, y, z ->
    println x   // group(1) -> /aaa wrong
    println y   // group(2) -> /aaa wrong
    println z   // group(3) -> aaa  right
}
```

a easy ways to fix it is use Regex Named Groups in Java 7 (we just supported java 8, not 6, right?), we can give every group a name, just change `(.*?)` to `(?<name>.*?)`, then we can use `matcher.group(name)` to get the group. i think it will be more useful.

[1]: https://groups.google.com/forum/#!topic/pippo-java/7GHaR7JTnuU