### PR TITLE
route group in pippo-controller

### DIFF
--- a/pippo-controller/src/main/java/ro/pippo/controller/ControllerApplication.java
+++ b/pippo-controller/src/main/java/ro/pippo/controller/ControllerApplication.java
@@ -75,6 +75,10 @@ public class ControllerApplication extends Application {
         return ALL(uriPattern, createRouteHandler(controllerClass, methodName));
     }
 
+    public ControllerRouteGroup newRouteGroup(String uriPattern, Class<? extends Controller> controllerClass) {
+        return new ControllerRouteGroup(uriPattern, controllerClass, this);
+    }
+
     public ControllerHandlerFactory getControllerHandlerFactory() {
         if (controllerHandlerFactory == null) {
             ControllerHandlerFactory factory = ServiceLocator.locate(ControllerHandlerFactory.class);

--- a/pippo-controller/src/main/java/ro/pippo/controller/ControllerRouteGroup.java
+++ b/pippo-controller/src/main/java/ro/pippo/controller/ControllerRouteGroup.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.controller;
+
+import ro.pippo.core.route.Route;
+import ro.pippo.core.util.StringUtils;
+
+
+/**
+ * @author ScienJus
+ * @date 16/2/14.
+ */
+public class ControllerRouteGroup {
+
+    private ControllerApplication application;
+
+    private Class<? extends Controller> controllerClass;
+
+    private String uriPattern;
+
+    public ControllerRouteGroup(String uriPattern, Class<? extends Controller> controllerClass, ControllerApplication application) {
+        this.uriPattern = uriPattern;
+        this.controllerClass = controllerClass;
+        this.application = application;
+    }
+
+    public Route GET(String uriPattern, String methodName) {
+        return application.GET(getAbsoluteUriPattern(uriPattern), controllerClass, methodName);
+    }
+
+    public Route GET(String methodName) {
+        return application.GET(uriPattern, controllerClass, methodName);
+    }
+
+    public Route POST(String uriPattern, String methodName) {
+        return application.POST(getAbsoluteUriPattern(uriPattern), controllerClass, methodName);
+    }
+
+    public Route POST(String methodName) {
+        return application.POST(uriPattern, controllerClass, methodName);
+    }
+
+    public Route DELETE(String uriPattern, String methodName) {
+        return application.DELETE(getAbsoluteUriPattern(uriPattern), controllerClass, methodName);
+    }
+
+    public Route DELETE(String methodName) {
+        return application.DELETE(uriPattern, controllerClass, methodName);
+    }
+
+    public Route HEAD(String uriPattern, String methodName) {
+        return application.HEAD(getAbsoluteUriPattern(uriPattern), controllerClass, methodName);
+    }
+
+    public Route HEAD(String methodName) {
+        return application.HEAD(uriPattern, controllerClass, methodName);
+    }
+
+    public Route PUT(String uriPattern, String methodName) {
+        return application.PUT(getAbsoluteUriPattern(uriPattern), controllerClass, methodName);
+    }
+
+    public Route PUT(String methodName) {
+        return application.PUT(uriPattern, controllerClass, methodName);
+    }
+
+    public Route PATCH(String uriPattern, String methodName) {
+        return application.PATCH(getAbsoluteUriPattern(uriPattern), controllerClass, methodName);
+    }
+
+    public Route PATCH(String methodName) {
+        return application.PATCH(uriPattern, controllerClass, methodName);
+    }
+
+    public Route ALL(String uriPattern, String methodName) {
+        return application.ALL(getAbsoluteUriPattern(uriPattern), controllerClass, methodName);
+    }
+
+    public Route ALL(String methodName) {
+        return application.ALL(uriPattern, controllerClass, methodName);
+    }
+
+
+    private String getAbsoluteUriPattern(String uriPattern) {
+        String absoluteUriPattern = StringUtils.addStart(StringUtils.addStart(uriPattern, "/"), this.uriPattern);
+        return "/".equals(absoluteUriPattern) ? absoluteUriPattern : StringUtils.removeEnd(absoluteUriPattern, "/");
+    }
+
+}


### PR DESCRIPTION
i think pippo controller do not need nested group, so it will be simpler like:

```
ControllerRouteGroup group = new ControllerRouteGroup("/users", UserController.class);
group.GET("{id}", 'get');
group.PUT("{id}", 'modify');

new ControllerApplication.addRouteGroup(group);
```

but there is one problem that we can't return a Route after`group.GET("{id}", 'get')`, because we need `controllerHandlerFactory` to create the `RouteHandler`.

so i created a new method named `newRouteGroup` in `CountrollerApllication` and give `controllerHandlerFactory` to `ControllerRouteGroup` in this method, then we can return the route we created. like:

```
ControllerApplication application = new ControllerApplication();

ControllerRouteGroup group = application.newRouteGroup("/users", UserController.class);
Route route = group.GET("{id}", 'get').named('getUser');
group.PUT("{id}", 'modify');

application.addRouteGroup(group);
```

absolutely, `inGroup` method can not be supported in this route.

then, i was thinking about why we need `Route.inGroup`, it can be instead of`RouteGroup.addRoute`, and if we removed this method, we can calculate absolute uri pattern before create a new Route, like:

```
//Application.newRouteGroup
public RouteGroup newRouteGroup(String uriPattern) {
    return new RouteGroup(uriPattern, this);    // <- give application to group
}

//RouteGroup.GET
public Route GET(String uriPattern, RouteHandler routeHandler) {
    return this.application.GET(getAbsoluteUriPattern(uriPattern), routeHandler);
}

//RouteGroup.getAbsoluteUriPattern
private String getAbsoluteUriPattern(String routeUriPattern) {
    return this.groupUriPattern + routeUriPattern
}
```

after that we also don't need `Route.group` and `RouteGroup.routes/parent/children`, all of them was exists just because `Route.inGroup` method. Do we really need them?

i will add tests in pippo-controller after we have decided how to make group api simpler and more useful.
