### PR TITLE
route group

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -195,11 +195,13 @@ public class DefaultRouter implements Router {
     @Override
     public void addRouteGroup(RouteGroup routeGroup) {
         routeGroup.getRoutes().forEach(this::addRoute);
+        routeGroup.getChildren().forEach(this::addRouteGroup);
     }
 
     @Override
     public void removeRouteGroup(RouteGroup routeGroup) {
         routeGroup.getRoutes().forEach(this::removeRoute);
+        routeGroup.getChildren().forEach(this::removeRouteGroup);
     }
 
     @Override

--- a/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DefaultRouter.java
@@ -195,13 +195,11 @@ public class DefaultRouter implements Router {
     @Override
     public void addRouteGroup(RouteGroup routeGroup) {
         routeGroup.getRoutes().forEach(this::addRoute);
-        routeGroup.getChildren().forEach(this::addRouteGroup);
     }
 
     @Override
     public void removeRouteGroup(RouteGroup routeGroup) {
         routeGroup.getRoutes().forEach(this::removeRoute);
-        routeGroup.getChildren().forEach(this::removeRouteGroup);
     }
 
     @Override

--- a/pippo-core/src/main/java/ro/pippo/core/route/RouteGroup.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/RouteGroup.java
@@ -33,24 +33,36 @@ public class RouteGroup {
 
     private String uriPattern;
     private List<Route> routes;
+    private List<RouteGroup> children;
 
     public RouteGroup(String uriPattern) {
         this.uriPattern = uriPattern;
         this.routes = new ArrayList<>();
+        this.children = new ArrayList<>();
     }
 
     public RouteGroup(RouteGroup parent, String uriPattern) {
         if (parent != null) {
             this.uriPattern = StringUtils.concatUriPattern(parent.getUriPattern(), uriPattern);
-            this.routes = parent.getRoutes();   // parent-children groups shared routes
+            parent.getChildren().add(this);
         } else {
             this.uriPattern = uriPattern;
-            this.routes = new ArrayList<>();
         }
+        this.routes = new ArrayList<>();
+        this.children = new ArrayList<>();
     }
 
     public String getUriPattern() {
         return this.uriPattern;
+    }
+
+    public List<RouteGroup> getChildren() {
+        return children;
+    }
+
+
+    public List<Route> getRoutes() {
+        return routes;
     }
 
     public Route GET(String uriPattern, RouteHandler routeHandler) {
@@ -125,10 +137,6 @@ public class RouteGroup {
 
     public Route ALL(RouteHandler routeHandler) {
         return ALL("", routeHandler);
-    }
-
-    public List<Route> getRoutes() {
-        return routes;
     }
 
     public RouteGroup addRoute(Route route) {

--- a/pippo-core/src/main/java/ro/pippo/core/route/RouteGroup.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/RouteGroup.java
@@ -16,6 +16,7 @@
 package ro.pippo.core.route;
 
 import ro.pippo.core.PippoRuntimeException;
+import ro.pippo.core.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,25 +33,24 @@ public class RouteGroup {
 
     private String uriPattern;
     private List<Route> routes;
-    private RouteGroup parent;
-    private List<RouteGroup> children;
 
     public RouteGroup(String uriPattern) {
         this.uriPattern = uriPattern;
         this.routes = new ArrayList<>();
-        this.children = new ArrayList<>();
+    }
+
+    public RouteGroup(RouteGroup parent, String uriPattern) {
+        if (parent != null) {
+            this.uriPattern = StringUtils.concatUriPattern(parent.getUriPattern(), uriPattern);
+            this.routes = parent.getRoutes();   // parent-children groups shared routes
+        } else {
+            this.uriPattern = uriPattern;
+            this.routes = new ArrayList<>();
+        }
     }
 
     public String getUriPattern() {
         return this.uriPattern;
-    }
-
-    public RouteGroup getParent() {
-        return parent;
-    }
-
-    public List<RouteGroup> getChildren() {
-        return children;
     }
 
     public Route GET(String uriPattern, RouteHandler routeHandler) {
@@ -58,7 +58,9 @@ public class RouteGroup {
             throw new PippoRuntimeException("Please use 'addResourceRoute()'");
         }
 
-        return Route.GET(uriPattern, routeHandler).inGroup(this);
+        Route route = Route.GET(uriPattern, routeHandler);
+        addRoute(route);
+        return route;
     }
 
     public Route GET(RouteHandler routeHandler) {
@@ -66,7 +68,9 @@ public class RouteGroup {
     }
 
     public Route POST(String uriPattern, RouteHandler routeHandler) {
-        return Route.POST(uriPattern, routeHandler).inGroup(this);
+        Route route = Route.POST(uriPattern, routeHandler);
+        addRoute(route);
+        return route;
     }
 
     public Route POST(RouteHandler routeHandler) {
@@ -74,7 +78,9 @@ public class RouteGroup {
     }
 
     public Route DELETE(String uriPattern, RouteHandler routeHandler) {
-        return Route.DELETE(uriPattern, routeHandler).inGroup(this);
+        Route route = Route.DELETE(uriPattern, routeHandler);
+        addRoute(route);
+        return route;
     }
 
     public Route DELETE(RouteHandler routeHandler) {
@@ -82,7 +88,9 @@ public class RouteGroup {
     }
 
     public Route HEAD(String uriPattern, RouteHandler routeHandler) {
-        return Route.HEAD(uriPattern, routeHandler).inGroup(this);
+        Route route = Route.HEAD(uriPattern, routeHandler);
+        addRoute(route);
+        return route;
     }
 
     public Route HEAD(RouteHandler routeHandler) {
@@ -90,7 +98,9 @@ public class RouteGroup {
     }
 
     public Route PUT(String uriPattern, RouteHandler routeHandler) {
-        return Route.PUT(uriPattern, routeHandler).inGroup(this);
+        Route route = Route.PUT(uriPattern, routeHandler);
+        addRoute(route);
+        return route;
     }
 
     public Route PUT(RouteHandler routeHandler) {
@@ -98,7 +108,9 @@ public class RouteGroup {
     }
 
     public Route PATCH(String uriPattern, RouteHandler routeHandler) {
-        return Route.PATCH(uriPattern, routeHandler).inGroup(this);
+        Route route = Route.PATCH(uriPattern, routeHandler);
+        addRoute(route);
+        return route;
     }
 
     public Route PATCH(RouteHandler routeHandler) {
@@ -106,7 +118,9 @@ public class RouteGroup {
     }
 
     public Route ALL(String uriPattern, RouteHandler routeHandler) {
-        return Route.ALL(uriPattern, routeHandler).inGroup(this);
+        Route route = Route.ALL(uriPattern, routeHandler);
+        addRoute(route);
+        return route;
     }
 
     public Route ALL(RouteHandler routeHandler) {
@@ -118,22 +132,10 @@ public class RouteGroup {
     }
 
     public RouteGroup addRoute(Route route) {
-        route.inGroup(this);
-
+        route.setGroupUriPattern(this.uriPattern);
+        routes.add(route);
         return this;
     }
 
-    public RouteGroup addRouteGroup(RouteGroup routeGroup) {
-        routeGroup.inGroup(this);
-
-        return this;
-    }
-
-    public RouteGroup inGroup(RouteGroup routeGroup) {
-        this.parent = routeGroup;
-        routeGroup.getChildren().add(this);
-
-        return this;
-    }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/util/StringUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/StringUtils.java
@@ -227,4 +227,8 @@ public class StringUtils {
         return input;
     }
 
+    public static String concatUriPattern(String prefix, String uriPattern) {
+        uriPattern = addStart(addStart(uriPattern, "/"), prefix);
+        return "/".equals(uriPattern) ? uriPattern : StringUtils.removeEnd(uriPattern, "/");
+    }
 }

--- a/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
@@ -669,41 +669,15 @@ public class DefaultRouterTest {
         assertEquals(1, matches.size());
     }
 
-    @Test
-    public void testRouteInGroup() {
-        RouteGroup group = new RouteGroup("/users");
-        Route route = new Route("GET", "{id}", emptyRouteHandler);
-        route.inGroup(group);
-
-        router.addRouteGroup(group);
-
-        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/users/1");
-        assertEquals(1, matches.size());
-    }
 
     @Test
-    public void testGroupAddGroup() {
+    public void testNestGroup() {
         RouteGroup group = new RouteGroup("/users");
-        RouteGroup child = new RouteGroup("{id}");
-        Route route = new Route("POST", "like", emptyRouteHandler);
-        group.addRouteGroup(child);
+        RouteGroup child = new RouteGroup(group, "{id}");
+        Route route = Route.POST("like", emptyRouteHandler);
         child.addRoute(route);
 
         router.addRouteGroup(group);
-
-        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.POST, "/users/1/like");
-        assertEquals(1, matches.size());
-    }
-
-    @Test
-    public void testGroupInGroup() {
-        RouteGroup group = new RouteGroup("/users");
-        RouteGroup child = new RouteGroup("{id}");
-        Route route = new Route("POST", "like", emptyRouteHandler);
-        child.inGroup(group);
-        route.inGroup(child);
-
-        router.addRoute(route);
 
         List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.POST, "/users/1/like");
         assertEquals(1, matches.size());


### PR DESCRIPTION
some description:

1, why use `setGroupUriPattern` and `absoluteUriPattern`? because i think maybe some people will repeated add route to group, like:

```
RouteGroup group1 = new RouteGroup("/users");
RouteGroup group2 = new RouteGroup("/posts");
Route route = Route.POST("like", emptyRouteHandler);
group1.addRoute(route);
group2.addRoute(route);  // it will raises an exception
```

2, why `parent-group` shared routes to `child-group`

```
public RouteGroup(RouteGroup parent, String uriPattern) {
    if (parent != null) {
        this.uriPattern = StringUtils.concatUriPattern(parent.getUriPattern(), uriPattern);
        this.routes = parent.getRoutes();   // parent-children groups shared routes
    } else {
        this.uriPattern = uriPattern;
        this.routes = new ArrayList<>();
    }
}
```

also because maybe some people forget add the top-group to application… like:

```
RouteGroup group = new RouteGroup("/users");
RouteGroup child = new RouteGroup(group, "{id}");
Route route = Route.POST("like", emptyRouteHandler);
child.addRoute(route);

// forget it
//router.addRouteGroup(group);

router.addRouteGroup(child);
```

what do you think?

there will be some problems if used improperly in group.