### PR TITLE
fixed the bug when underline in path parameter name

### DIFF
--- a/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
@@ -26,6 +26,7 @@ import ro.pippo.core.route.RouteGroup;
 import ro.pippo.core.route.RouteHandler;
 import ro.pippo.core.route.RouteMatch;
 import ro.pippo.core.route.WebjarsResourceHandler;
+import ro.pippo.core.util.PathRegexBuilder;
 
 import java.util.HashMap;
 import java.util.List;
@@ -708,6 +709,14 @@ public class DefaultRouterTest {
             GET(emptyRouteHandler);
         }
 
+    }
+
+    @Test
+    public void testUnderlineInPathParameter() throws Exception {
+        router.addRoute(Route.GET("/{user_id}", emptyRouteHandler));
+
+        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/123");
+        assertEquals(1, matches.size());
     }
 
 }

--- a/pippo-core/src/test/java/ro/pippo/core/PathRegexBuilderTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/PathRegexBuilderTest.java
@@ -208,4 +208,22 @@ public class PathRegexBuilderTest {
         assertEquals("aaa", parameterMap.get("name"));
     }
 
+    @Test
+    public void testUnderlineInPathParameter() throws Exception {
+        String uri = "/aaa";
+
+        String regex = new PathRegexBuilder()
+            .includes(
+                "/{user_id}"
+            )
+            .excludes(
+                "/admin"
+            )
+            .build();
+
+        router.addRoute(Route.GET(regex, emptyRouteHandler));
+        Map<String, String> parameterMap = router.findRoutes("GET", uri).get(0).getPathParameters();
+        assertEquals("aaa", parameterMap.get("user_id"));
+    }
+
 }


### PR DESCRIPTION
in https://github.com/decebals/pippo/pull/249 i try to use regex named group to fix wrong path parameter value bug. but there will have a new problem that underline is not supported in group name. for example if the uri pattern like `/{user_id}`, there will be a `PatternSyntaxException`:

```
java.util.regex.PatternSyntaxException: named capturing group is missing trailing '>' near index 8
/(?<user_id>[^/]+)
```

so i have to change group name from parameter name to parameter index like `/(?<param1>[^/]+)`(`/(?<1>[^/]+)` is not supported too).