### PR TITLE
Use the trustStore only when client authentication is enabled

### DIFF
--- a/pippo-tomcat/src/main/java/ro/pippo/tomcat/TomcatServer.java
+++ b/pippo-tomcat/src/main/java/ro/pippo/tomcat/TomcatServer.java
@@ -107,9 +107,11 @@ public class TomcatServer extends AbstractWebServer<TomcatSettings> {
         connector.setAttribute("keystorePass", getSettings().getKeystorePassword());
         connector.setAttribute("keystoreType", getSettings().getKeyType());
         connector.setAttribute("keystoreFile", getSettings().getKeystoreFile());
-        connector.setAttribute("truststoreFile", getSettings().getTruststoreFile());
-        connector.setAttribute("truststorePass", getSettings().getTruststorePassword());
         connector.setAttribute("clientAuth", getSettings().getClientAuth());
+        if (getSettings().getClientAuth()){
+        	connector.setAttribute("truststoreFile", getSettings().getTruststoreFile());
+            connector.setAttribute("truststorePass", getSettings().getTruststorePassword());
+        }
         connector.setAttribute("protocol", "HTTP/1.1");
         connector.setAttribute("sslProtocol", "TLS");
         connector.setAttribute("maxThreads", getSettings().getMaxConnections());


### PR DESCRIPTION
Added the condition as @JPercivall suggested on issue #262 