### PR TITLE
multiple code improvements: squid:S1068, squid:ClassVariableVisibilityCheck, squid:S2131, squid:S1192, squid:S1488, squid:S1066, squid:S1596, squid:S1170

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/DefaultErrorHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/DefaultErrorHandler.java
@@ -40,6 +40,8 @@ public class DefaultErrorHandler implements ErrorHandler {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultErrorHandler.class);
 
+    private static final String MESSAGE = "message";
+
     private Application application;
 
     private final Map<Class<? extends Exception>, ExceptionHandler> exceptionHandlers;
@@ -84,8 +86,7 @@ public class DefaultErrorHandler implements ErrorHandler {
             exceptionHandlers.put(exceptionClass, null);
         }
 
-        ExceptionHandler exceptionHandler = exceptionHandlers.get(exceptionClass);
-        return exceptionHandler;
+        return exceptionHandlers.get(exceptionClass);
     }
 
     @Override
@@ -185,8 +186,8 @@ public class DefaultErrorHandler implements ErrorHandler {
         }
 
         String message = exception.getMessage();
-        if (!StringUtils.isNullOrEmpty(message) && !routeContext.getResponse().getLocals().containsKey("message")) {
-            routeContext.setLocal("message", message);
+        if (!StringUtils.isNullOrEmpty(message) && !routeContext.getResponse().getLocals().containsKey(MESSAGE)) {
+            routeContext.setLocal(MESSAGE, message);
         }
 
         if (application.getPippoSettings().isDev()) {
@@ -259,13 +260,13 @@ public class DefaultErrorHandler implements ErrorHandler {
         String messageKey = "pippo.statusCode" + statusCode;
 
         Error error = new Error();
-        error.statusCode = statusCode;
-        error.statusMessage = application.getMessages().get(messageKey, routeContext);
-        error.requestMethod = routeContext.getRequestMethod();
-        error.requestUri = routeContext.getRequestUri();
-        error.requestUri = routeContext.getRequestUri();
-        error.stacktrace = routeContext.getLocal("stacktrace");
-        error.message = routeContext.getLocal("message");
+        error.setStatusCode(statusCode);
+        error.setStatusMessage(application.getMessages().get(messageKey, routeContext));
+        error.setRequestMethod(routeContext.getRequestMethod());
+        error.setRequestUri(routeContext.getRequestUri());
+        error.setRequestUri(routeContext.getRequestUri());
+        error.setStacktrace(routeContext.getLocal("stacktrace"));
+        error.setMessage(routeContext.getLocal(MESSAGE));
 
         return error;
     }

--- a/pippo-core/src/main/java/ro/pippo/core/Error.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Error.java
@@ -34,14 +34,62 @@ public class Error implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    public int statusCode;
-    public String statusMessage;
-    public String requestMethod;
-    public String requestUri;
-    public String message;
-    public String stacktrace;
+    private int statusCode;
+    private String statusMessage;
+    private String requestMethod;
+    private String requestUri;
+    private String message;
+    private String stacktrace;
 
     public Error() {
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public String getStatusMessage() {
+        return statusMessage;
+    }
+
+    public void setStatusMessage(String statusMessage) {
+        this.statusMessage = statusMessage;
+    }
+
+    public String getRequestMethod() {
+        return requestMethod;
+    }
+
+    public void setRequestMethod(String requestMethod) {
+        this.requestMethod = requestMethod;
+    }
+
+    public String getRequestUri() {
+        return requestUri;
+    }
+
+    public void setRequestUri(String requestUri) {
+        this.requestUri = requestUri;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getStacktrace() {
+        return stacktrace;
+    }
+
+    public void setStacktrace(String stacktrace) {
+        this.stacktrace = stacktrace;
     }
 
     @Override

--- a/pippo-core/src/main/java/ro/pippo/core/Flash.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Flash.java
@@ -90,7 +90,7 @@ public class Flash implements Iterable<Flash.Message>, Serializable {
     }
 
     public List<String> getErrorList() {
-        return hasError() ? get(Message.ERROR) : Collections.EMPTY_LIST;
+        return hasError() ? get(Message.ERROR) : Collections.emptyList();
     }
 
     public void success(String message) {
@@ -110,7 +110,7 @@ public class Flash implements Iterable<Flash.Message>, Serializable {
     }
 
     public List<String> getSuccessList() {
-        return hasSuccess() ? get(Message.SUCCESS) : Collections.EMPTY_LIST;
+        return hasSuccess() ? get(Message.SUCCESS) : Collections.emptyList();
     }
 
     public void warning(String message) {
@@ -130,7 +130,7 @@ public class Flash implements Iterable<Flash.Message>, Serializable {
     }
 
     public List<String> getWarningList() {
-        return hasWarning() ? get(Message.WARNING) : Collections.EMPTY_LIST;
+        return hasWarning() ? get(Message.WARNING) : Collections.emptyList();
     }
 
     public void info(String message) {
@@ -150,7 +150,7 @@ public class Flash implements Iterable<Flash.Message>, Serializable {
     }
 
     public List<String> getInfoList() {
-        return hasInfo() ? get(Message.INFO) : Collections.EMPTY_LIST;
+        return hasInfo() ? get(Message.INFO) : Collections.emptyList();
     }
 
     @Override

--- a/pippo-core/src/main/java/ro/pippo/core/Languages.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Languages.java
@@ -40,7 +40,7 @@ public class Languages {
 
     private final String applicationCookiePrefix;
 
-    private final int TEN_YEARS = 60 * 60 * 24 * 365 * 10;
+    private static final int TEN_YEARS = 60 * 60 * 24 * 365 * 10;
 
     private final PippoSettings pippoSettings;
 
@@ -180,20 +180,14 @@ public class Languages {
         // The Response always has priority over the Request because it may have
         // been set earlier in the HandlerChain.
         Cookie cookie = routeContext.getResponse().getCookie(cookieName);
-        if (cookie != null) {
-            if (!StringUtils.isNullOrEmpty(cookie.getValue())) {
-                String language = getLanguageOrDefault(cookie.getValue());
-                return language;
-            }
+        if (cookie != null && !StringUtils.isNullOrEmpty(cookie.getValue())) {
+            return getLanguageOrDefault(cookie.getValue());
         }
 
         // Step 2: Look for a Request cookie.
         cookie = routeContext.getRequest().getCookie(cookieName);
-        if (cookie != null) {
-            if (!StringUtils.isNullOrEmpty(cookie.getValue())) {
-                String language = getLanguageOrDefault(cookie.getValue());
-                return language;
-            }
+        if (cookie != null && !StringUtils.isNullOrEmpty(cookie.getValue())) {
+            return getLanguageOrDefault(cookie.getValue());
         }
 
         // Step 3: Look for a lang parameter in the response locals
@@ -205,9 +199,7 @@ public class Languages {
 
         // Step 4: Look for a language in the Accept-Language header.
         String acceptLanguage = routeContext.getHeader(HttpConstants.Header.ACCEPT_LANGUAGE);
-        String language = getLanguageOrDefault(acceptLanguage);
-
-        return language;
+        return getLanguageOrDefault(acceptLanguage);
     }
 
     /**
@@ -294,8 +286,7 @@ public class Languages {
         }
 
         // the first language specified is the default language
-        String defaultLanguage = applicationLanguages.get(0);
-        return defaultLanguage;
+        return applicationLanguages.get(0);
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/Messages.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Messages.java
@@ -114,8 +114,7 @@ public class Messages {
         Properties messages = getMessagesForLanguage(language);
         String value = messages.getProperty(key);
         if (value != null) {
-            String message = formatMessage(value, language, args);
-            return message;
+            return formatMessage(value, language, args);
         } else {
             log.warn("Failed to find '{}' in Messages", key);
             return key;

--- a/pippo-core/src/main/java/ro/pippo/core/PippoSettings.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoSettings.java
@@ -85,7 +85,9 @@ public class PippoSettings {
 
     private static final Logger log = LoggerFactory.getLogger(PippoSettings.class);
 
-    private final String defaultListDelimiter = ",";
+    private static final String USING_DEFAULT_OF = " using default of ";
+
+    private static final String defaultListDelimiter = ",";
 
     private final RuntimeMode runtimeMode;
 
@@ -457,8 +459,7 @@ public class PippoSettings {
      */
     public String getInterpolatedString(String name, String defaultValue) {
         String value = getString(name, defaultValue);
-        final String interpolatedValue = interpolateString(value);
-        return interpolatedValue;
+        return interpolateString(value);
     }
 
     /**
@@ -495,7 +496,7 @@ public class PippoSettings {
                 return Integer.parseInt(value.trim().split(" ")[0]);
             }
         } catch (NumberFormatException e) {
-            log.warn("Failed to parse integer for " + name + " using default of "
+            log.warn("Failed to parse integer for " + name + USING_DEFAULT_OF
                 + defaultValue);
         }
 
@@ -518,7 +519,7 @@ public class PippoSettings {
                 return Long.parseLong(value.trim().split(" ")[0]);
             }
         } catch (NumberFormatException e) {
-            log.warn("Failed to parse long for " + name + " using default of "
+            log.warn("Failed to parse long for " + name + USING_DEFAULT_OF
                 + defaultValue);
         }
 
@@ -541,7 +542,7 @@ public class PippoSettings {
                 return Float.parseFloat(value.trim().split(" ")[0]);
             }
         } catch (NumberFormatException e) {
-            log.warn("Failed to parse float for " + name + " using default of "
+            log.warn("Failed to parse float for " + name + USING_DEFAULT_OF
                 + defaultValue);
         }
 
@@ -564,7 +565,7 @@ public class PippoSettings {
                 return Double.parseDouble(value.trim().split(" ")[0]);
             }
         } catch (NumberFormatException e) {
-            log.warn("Failed to parse double for " + name + " using default of "
+            log.warn("Failed to parse double for " + name + USING_DEFAULT_OF
                 + defaultValue);
         }
 
@@ -626,9 +627,7 @@ public class PippoSettings {
         if (StringUtils.isNullOrEmpty(value)) {
             return Collections.emptyList();
         }
-        List<String> stringList = StringUtils.getList(value, delimiter);
-
-        return stringList;
+        return StringUtils.getList(value, delimiter);
     }
 
     /**
@@ -946,7 +945,7 @@ public class PippoSettings {
      * @param value
      */
     public void overrideSetting(String name, boolean value) {
-        overrides.put(name, "" + value);
+        overrides.put(name, Boolean.toString(value));
     }
 
     /**
@@ -968,7 +967,7 @@ public class PippoSettings {
      * @param value
      */
     public void overrideSetting(String name, char value) {
-        overrides.put(name, "" + value);
+        overrides.put(name, Character.toString(value));
     }
 
     /**
@@ -979,7 +978,7 @@ public class PippoSettings {
      * @param value
      */
     public void overrideSetting(String name, int value) {
-        overrides.put(name, "" + value);
+        overrides.put(name, Integer.toString(value));
     }
 
     /**
@@ -990,7 +989,7 @@ public class PippoSettings {
      * @param value
      */
     public void overrideSetting(String name, long value) {
-        overrides.put(name, "" + value);
+        overrides.put(name, Long.toString(value));
     }
 
     /**
@@ -1001,7 +1000,7 @@ public class PippoSettings {
      * @param value
      */
     public void overrideSetting(String name, float value) {
-        overrides.put(name, "" + value);
+        overrides.put(name, Float.toString(value));
     }
 
     /**
@@ -1012,7 +1011,7 @@ public class PippoSettings {
      * @param value
      */
     public void overrideSetting(String name, double value) {
-        overrides.put(name, "" + value);
+        overrides.put(name, Double.toString(value));
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/Session.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Session.java
@@ -28,6 +28,8 @@ import java.util.Map;
  */
 public class Session {
 
+    private static final String FLASH = "flash";
+
     private HttpSession httpSession;
 
     public Session(HttpSession httpSession) {
@@ -69,9 +71,9 @@ public class Session {
     }
 
     public Flash getFlash() {
-        Flash flash = get("flash");
+        Flash flash = get(FLASH);
         if (flash == null) {
-            put("flash", flash = new Flash());
+            put(FLASH, flash = new Flash());
         }
 
         return flash;
@@ -97,7 +99,7 @@ public class Session {
         Enumeration<String> names = getNames();
         while (names.hasMoreElements() ) {
             String name = names.nextElement();
-            if ("flash".equalsIgnoreCase(name)) {
+            if (FLASH.equalsIgnoreCase(name)) {
                 continue;
             }
 

--- a/pippo-core/src/main/java/ro/pippo/core/StatusCodeException.java
+++ b/pippo-core/src/main/java/ro/pippo/core/StatusCodeException.java
@@ -36,7 +36,7 @@ public class StatusCodeException extends PippoRuntimeException {
     }
 
     public StatusCodeException(int statusCode) {
-        super("" + statusCode);
+        super(Integer.toString(statusCode));
         this.statusCode = statusCode;
     }
 

--- a/pippo-csv/src/main/java/ro/pippo/csv/CsvInitializer.java
+++ b/pippo-csv/src/main/java/ro/pippo/csv/CsvInitializer.java
@@ -27,8 +27,6 @@ import ro.pippo.core.Initializer;
 @MetaInfServices(Initializer.class)
 public class CsvInitializer implements Initializer {
 
-    private static final Logger log = LoggerFactory.getLogger(CsvInitializer.class);
-
     @Override
     public void init(Application application) {
         application.registerContentTypeEngine(CsvEngine.class);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1068 - Unused private fields should be removed.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
squid:S1192 - String literals should not be duplicated.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1066 - Collapsible "if" statements should be merged.
squid:S1596 - Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET.
squid:S1170 - Public constants should be declared "static final" rather than merely "final".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S1596
https://dev.eclipse.org/sonar/rules/show/squid:S1170
Please let me know if you have any questions.
George Kankava