### PR TITLE
multiple code improvements: squid:S1118, squid:S00117, squid:S1197, squid:CommentedOutCodeLine, squid:S00122, squid:S2092, squid:S00115

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/Languages.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Languages.java
@@ -266,6 +266,7 @@ public class Languages {
      */
     private Cookie generateLanguageCookie(String language) {
         Cookie cookie = new Cookie(applicationCookiePrefix + "_LANG", language);
+        cookie.setSecure(true);
         cookie.setMaxAge(TEN_YEARS);
         return cookie;
     }

--- a/pippo-core/src/main/java/ro/pippo/core/PippoSettings.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoSettings.java
@@ -87,7 +87,7 @@ public class PippoSettings {
 
     private static final String USING_DEFAULT_OF = " using default of ";
 
-    private static final String defaultListDelimiter = ",";
+    private static final String DEFAULT_LIST_DELIMITER = ",";
 
     private final RuntimeMode runtimeMode;
 
@@ -301,7 +301,7 @@ public class PippoSettings {
         String include = (String) currentProperties.remove(key);
         if (!StringUtils.isNullOrEmpty(include)) {
             // allow for multiples
-            List<String> names = StringUtils.getList(include, defaultListDelimiter);
+            List<String> names = StringUtils.getList(include, DEFAULT_LIST_DELIMITER);
             for (String name : names) {
                 if (StringUtils.isNullOrEmpty(name)) {
                     continue;
@@ -612,7 +612,7 @@ public class PippoSettings {
      * @return list of strings
      */
     public List<String> getStrings(String name) {
-        return getStrings(name, defaultListDelimiter);
+        return getStrings(name, DEFAULT_LIST_DELIMITER);
     }
 
     /**
@@ -637,7 +637,7 @@ public class PippoSettings {
      * @return list of strings
      */
     public List<Integer> getIntegers(String name) {
-        return getIntegers(name, defaultListDelimiter);
+        return getIntegers(name, DEFAULT_LIST_DELIMITER);
     }
 
     /**
@@ -672,7 +672,7 @@ public class PippoSettings {
      * @return list of strings
      */
     public List<Long> getLongs(String name) {
-        return getLongs(name, defaultListDelimiter);
+        return getLongs(name, DEFAULT_LIST_DELIMITER);
     }
 
     /**

--- a/pippo-core/src/main/java/ro/pippo/core/Response.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Response.java
@@ -170,6 +170,7 @@ public final class Response {
      */
     public Response cookie(String name, String value) {
         Cookie cookie = new Cookie(name, value);
+        cookie.setSecure(true);
         addCookie(cookie);
 
         return this;
@@ -185,6 +186,7 @@ public final class Response {
      */
     public Response cookie(String name, String value, int maxAge) {
         Cookie cookie = new Cookie(name, value);
+        cookie.setSecure(true);
         cookie.setMaxAge(maxAge);
         addCookie(cookie);
 
@@ -240,6 +242,7 @@ public final class Response {
      */
     public Response removeCookie(String name) {
         Cookie cookie = new Cookie(name, "");
+        cookie.setSecure(true);
         cookie.setMaxAge(0);
         addCookie(cookie);
 
@@ -977,7 +980,6 @@ public final class Response {
         // add session (if exists) to model
         Session session = Session.get();
         if (session != null) {
-//            model.put("session", session.getAll());
             model.put("session", session);
         }
 

--- a/pippo-core/src/main/java/ro/pippo/core/WebServerSettings.java
+++ b/pippo-core/src/main/java/ro/pippo/core/WebServerSettings.java
@@ -24,10 +24,10 @@ public class WebServerSettings implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final int defaultPort = 8338;
+    private static final int DEFAULT_PORT = 8338;
 
     private String host = "localhost";
-    private int port = defaultPort;
+    private int port = DEFAULT_PORT;
     private String contextPath = "/";
     private String keystoreFile;
     private String keystorePassword;
@@ -35,7 +35,7 @@ public class WebServerSettings implements Serializable {
     private String truststorePassword;
 
     public WebServerSettings(PippoSettings pippoSettings) {
-        this.port = pippoSettings.getInteger(PippoConstants.SETTING_SERVER_PORT, defaultPort);
+        this.port = pippoSettings.getInteger(PippoConstants.SETTING_SERVER_PORT, DEFAULT_PORT);
         this.host = pippoSettings.getString(PippoConstants.SETTING_SERVER_HOST, host);
         this.contextPath = pippoSettings.getString(PippoConstants.SETTING_SERVER_CONTEXT_PATH, contextPath);
         this.keystoreFile = pippoSettings.getString(PippoConstants.SETTING_SERVER_KEYSTORE_FILE, keystoreFile);

--- a/pippo-core/src/main/java/ro/pippo/core/route/Route.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Route.java
@@ -164,13 +164,21 @@ public class Route {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Route route = (Route) o;
 
-        if (!requestMethod.equals(route.requestMethod)) return false;
-        if (!getUriPattern().equals(route.getUriPattern())) return false;
+        if (!requestMethod.equals(route.requestMethod)) {
+            return false;
+        }
+        if (!getUriPattern().equals(route.getUriPattern())) {
+            return false;
+        }
 
         return true;
     }

--- a/pippo-core/src/main/java/ro/pippo/core/util/ClassUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/ClassUtils.java
@@ -25,6 +25,8 @@ import java.util.List;
  */
 public class ClassUtils {
 
+    private ClassUtils() {}
+
     public static List<Field> getAllFields(Class clazz) {
         List<Field> allFields = new ArrayList<>();
         allFields.addAll(Arrays.asList(clazz.getDeclaredFields()));

--- a/pippo-core/src/main/java/ro/pippo/core/util/ClasspathUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/ClasspathUtils.java
@@ -32,6 +32,8 @@ public class ClasspathUtils {
 
     private final static Logger log = LoggerFactory.getLogger(ClasspathUtils.class);
 
+    private ClasspathUtils() {}
+
     /**
      * Tries to find a resource with the given name in the classpath.
      *

--- a/pippo-core/src/main/java/ro/pippo/core/util/CookieUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/CookieUtils.java
@@ -26,6 +26,8 @@ import java.util.List;
  */
 public class CookieUtils {
 
+    private CookieUtils() {}
+
     public static List<Cookie> getCookies(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if ((cookies == null) || (cookies.length == 0)) {

--- a/pippo-core/src/main/java/ro/pippo/core/util/CryptoUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/CryptoUtils.java
@@ -35,6 +35,8 @@ public class CryptoUtils {
 
     public static final String HMAC_SHA256 = "HmacSHA256";
 
+    private CryptoUtils() {}
+
     public static String getHmacSHA256(String message, String secretKey) {
         return hmacDigest(message, secretKey, HMAC_SHA256);
     }

--- a/pippo-core/src/main/java/ro/pippo/core/util/DateUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/DateUtils.java
@@ -26,6 +26,8 @@ import java.util.Locale;
  */
 public class DateUtils {
 
+    private DateUtils() {}
+
     /**
      * From here: http://www.ietf.org/rfc/rfc1123.txt
      */

--- a/pippo-core/src/main/java/ro/pippo/core/util/IoUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/IoUtils.java
@@ -34,6 +34,8 @@ import java.nio.charset.StandardCharsets;
  */
 public class IoUtils {
 
+    private IoUtils() {}
+
     /**
      * Copies all data from an InputStream to an OutputStream.
      *
@@ -41,7 +43,7 @@ public class IoUtils {
      * @throws IOException if an I/O error occurs
      */
     public static long copy(InputStream input, OutputStream output) throws IOException {
-        byte buffer[] = new byte[2 * 1024];
+        byte[] buffer = new byte[2 * 1024];
         long total = 0;
         int count;
         while ((count = input.read(buffer)) != -1) {

--- a/pippo-core/src/main/java/ro/pippo/core/util/LangUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/LangUtils.java
@@ -22,6 +22,8 @@ import java.lang.reflect.Method;
  */
 public class LangUtils {
 
+    private LangUtils() {}
+
     public static String toString(Method method) {
         return method.getDeclaringClass().getName() + "::" + method.getName();
     }

--- a/pippo-core/src/main/java/ro/pippo/core/util/PippoUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/PippoUtils.java
@@ -33,6 +33,8 @@ public class PippoUtils {
         + " ) __/ _)(_  ) __/ ) __/ )(_)(   http://pippo.ro\n"
         + "(__)  (____)(__)  (__)  (_____)  {}\n";
 
+    private PippoUtils() {}
+
     public static String getPippoLogo() {
         return StringUtils.format(PIPPO_LOGO, getPippoVersion());
     }
@@ -45,7 +47,7 @@ public class PippoUtils {
      */
     public static String getPippoVersion() {
         // and the key inside the properties file.
-        String PIPPO_VERSION_PROPERTY_KEY = "pippo.version";
+        String pippoVersionPropertyKey = "pippo.version";
 
         String pippoVersion;
 
@@ -55,7 +57,7 @@ public class PippoUtils {
             InputStream stream = url.openStream();
             prop.load(stream);
 
-            pippoVersion = prop.getProperty(PIPPO_VERSION_PROPERTY_KEY);
+            pippoVersion = prop.getProperty(pippoVersionPropertyKey);
         } catch (Exception e) {
             //this should not happen. Never.
             throw new PippoRuntimeException("Something is wrong with your build. Cannot find resource {}",

--- a/pippo-core/src/main/java/ro/pippo/core/util/StringUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/StringUtils.java
@@ -25,6 +25,8 @@ import java.util.regex.PatternSyntaxException;
  */
 public class StringUtils {
 
+    private StringUtils() {}
+
     public static boolean isNullOrEmpty(String s) {
         return s == null || s.trim().isEmpty();
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S00122 - Statements should be on separate lines.
squid:S2092 - Cookies should be "secure".
squid:S00115 - Constant names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:S2092
https://dev.eclipse.org/sonar/rules/show/squid:S00115
Please let me know if you have any questions.
George Kankava