### PR TITLE
multiple code improvements: squid:S1068, squid:S1854, squid:S1192, squid:S00115, squid:UselessParenthesesCheck

### DIFF
--- a/pippo-fastjson/src/main/java/ro/pippo/fastjson/FastjsonInitializer.java
+++ b/pippo-fastjson/src/main/java/ro/pippo/fastjson/FastjsonInitializer.java
@@ -16,8 +16,6 @@
 package ro.pippo.fastjson;
 
 import org.kohsuke.MetaInfServices;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ro.pippo.core.Application;
 import ro.pippo.core.Initializer;
@@ -27,8 +25,6 @@ import ro.pippo.core.Initializer;
  */
 @MetaInfServices(Initializer.class)
 public class FastjsonInitializer implements Initializer {
-
-    private static final Logger log = LoggerFactory.getLogger(FastjsonInitializer.class);
 
     @Override
     public void init(Application application) {

--- a/pippo-freemarker/src/main/java/ro/pippo/freemarker/FormatTimeMethod.java
+++ b/pippo-freemarker/src/main/java/ro/pippo/freemarker/FormatTimeMethod.java
@@ -21,9 +21,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import ro.pippo.core.PippoRuntimeException;
 import freemarker.template.SimpleDate;
 import freemarker.template.SimpleScalar;
@@ -38,8 +35,6 @@ import freemarker.template.TemplateModelException;
  *
  */
 public class FormatTimeMethod implements TemplateMethodModelEx {
-
-    private final static Logger log = LoggerFactory.getLogger(FormatTimeMethod.class);
 
     private final Locale locale;
 

--- a/pippo-freemarker/src/main/java/ro/pippo/freemarker/FreemarkerInitializer.java
+++ b/pippo-freemarker/src/main/java/ro/pippo/freemarker/FreemarkerInitializer.java
@@ -16,8 +16,6 @@
 package ro.pippo.freemarker;
 
 import org.kohsuke.MetaInfServices;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ro.pippo.core.Application;
 import ro.pippo.core.Initializer;
@@ -27,8 +25,6 @@ import ro.pippo.core.Initializer;
  */
 @MetaInfServices(Initializer.class)
 public class FreemarkerInitializer implements Initializer {
-
-    private static final Logger log = LoggerFactory.getLogger(FreemarkerInitializer.class);
 
     @Override
     public void init(Application application) {

--- a/pippo-freemarker/src/main/java/ro/pippo/freemarker/I18nMethod.java
+++ b/pippo-freemarker/src/main/java/ro/pippo/freemarker/I18nMethod.java
@@ -18,9 +18,6 @@ package ro.pippo.freemarker;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import ro.pippo.core.Messages;
 import freemarker.ext.beans.StringModel;
 import freemarker.template.SimpleNumber;
@@ -36,8 +33,6 @@ import freemarker.template.TemplateModelException;
  * @author James Moger
  */
 public class I18nMethod implements TemplateMethodModelEx {
-
-    private final static Logger log = LoggerFactory.getLogger(I18nMethod.class);
 
     final Messages messages;
     final String language;

--- a/pippo-freemarker/src/main/java/ro/pippo/freemarker/PrettyTimeMethod.java
+++ b/pippo-freemarker/src/main/java/ro/pippo/freemarker/PrettyTimeMethod.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Locale;
 
 import org.ocpsoft.prettytime.PrettyTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ro.pippo.core.PippoRuntimeException;
 import freemarker.template.SimpleDate;
@@ -37,8 +35,6 @@ import freemarker.template.TemplateModelException;
  * @author James Moger
  */
 public class PrettyTimeMethod implements TemplateMethodModelEx {
-
-    private final static Logger log = LoggerFactory.getLogger(PrettyTimeMethod.class);
 
     private final PrettyTime prettyTime;
 

--- a/pippo-groovy/src/main/java/ro/pippo/groovy/GroovyInitializer.java
+++ b/pippo-groovy/src/main/java/ro/pippo/groovy/GroovyInitializer.java
@@ -16,8 +16,6 @@
 package ro.pippo.groovy;
 
 import org.kohsuke.MetaInfServices;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ro.pippo.core.Application;
 import ro.pippo.core.Initializer;
@@ -27,8 +25,6 @@ import ro.pippo.core.Initializer;
  */
 @MetaInfServices(Initializer.class)
 public class GroovyInitializer implements Initializer {
-
-    private static final Logger log = LoggerFactory.getLogger(GroovyInitializer.class);
 
     @Override
     public void init(Application application) {

--- a/pippo-groovy/src/main/java/ro/pippo/groovy/GroovyTemplateEngine.java
+++ b/pippo-groovy/src/main/java/ro/pippo/groovy/GroovyTemplateEngine.java
@@ -98,7 +98,7 @@ public class GroovyTemplateEngine implements TemplateEngine {
     public void renderString(String templateContent, Map<String, Object> model, Writer writer) {
         try {
             Template groovyTemplate = engine.createTemplate(templateContent);
-            PippoGroovyTemplate gt = ((PippoGroovyTemplate) groovyTemplate.make(model));
+            PippoGroovyTemplate gt = (PippoGroovyTemplate) groovyTemplate.make(model);
             gt.setup(languages, messages, router);
             gt.writeTo(writer);
         } catch (Exception e) {
@@ -122,7 +122,7 @@ public class GroovyTemplateEngine implements TemplateEngine {
         }
 
         try {
-            PippoGroovyTemplate gt = ((PippoGroovyTemplate) groovyTemplate.make(model));
+            PippoGroovyTemplate gt = (PippoGroovyTemplate) groovyTemplate.make(model);
             gt.setup(languages, messages, router);
             gt.writeTo(writer);
         } catch (Exception e) {

--- a/pippo-groovy/src/main/java/ro/pippo/groovy/PippoGroovyTemplate.java
+++ b/pippo-groovy/src/main/java/ro/pippo/groovy/PippoGroovyTemplate.java
@@ -31,8 +31,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.ocpsoft.prettytime.PrettyTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ro.pippo.core.Languages;
 import ro.pippo.core.Messages;
@@ -50,8 +48,6 @@ import ro.pippo.core.util.StringUtils;
  * @author James Moger
  */
 public abstract class PippoGroovyTemplate extends BaseTemplate {
-
-    private final Logger log = LoggerFactory.getLogger(PippoGroovyTemplate.class);
 
     private final Map<String, String> modelTypes;
 

--- a/pippo-gson/src/main/java/ro/pippo/gson/GsonInitializer.java
+++ b/pippo-gson/src/main/java/ro/pippo/gson/GsonInitializer.java
@@ -16,8 +16,6 @@
 package ro.pippo.gson;
 
 import org.kohsuke.MetaInfServices;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ro.pippo.core.Application;
 import ro.pippo.core.Initializer;
@@ -27,8 +25,6 @@ import ro.pippo.core.Initializer;
  */
 @MetaInfServices(Initializer.class)
 public class GsonInitializer implements Initializer {
-
-    private static final Logger log = LoggerFactory.getLogger(GsonInitializer.class);
 
     @Override
     public void init(Application application) {

--- a/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonInitializer.java
+++ b/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonInitializer.java
@@ -16,8 +16,7 @@
 package ro.pippo.jackson;
 
 import org.kohsuke.MetaInfServices;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import ro.pippo.core.Application;
 import ro.pippo.core.Initializer;
 import ro.pippo.core.util.ClasspathUtils;
@@ -27,8 +26,6 @@ import ro.pippo.core.util.ClasspathUtils;
  */
 @MetaInfServices(Initializer.class)
 public class JacksonInitializer implements Initializer {
-
-    private static final Logger log = LoggerFactory.getLogger(JacksonInitializer.class);
 
     @Override
     public void init(Application application) {

--- a/pippo-jade/src/main/java/ro/pippo/jade/JadeInitializer.java
+++ b/pippo-jade/src/main/java/ro/pippo/jade/JadeInitializer.java
@@ -16,8 +16,6 @@
 package ro.pippo.jade;
 
 import org.kohsuke.MetaInfServices;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ro.pippo.core.Application;
 import ro.pippo.core.Initializer;
@@ -27,8 +25,6 @@ import ro.pippo.core.Initializer;
  */
 @MetaInfServices(Initializer.class)
 public class JadeInitializer implements Initializer {
-
-    private static final Logger log = LoggerFactory.getLogger(JadeInitializer.class);
 
     @Override
     public void init(Application application) {

--- a/pippo-jade/src/main/java/ro/pippo/jade/JadeTemplateEngine.java
+++ b/pippo-jade/src/main/java/ro/pippo/jade/JadeTemplateEngine.java
@@ -139,7 +139,7 @@ public class JadeTemplateEngine implements TemplateEngine {
 
     private static class ClassTemplateLoader implements TemplateLoader {
 
-        private static final String suffix = ".jade";
+        private static final String SUFFIX = ".jade";
 
         private Class<?> clazz;
         private String pathPrefix;
@@ -163,8 +163,8 @@ public class JadeTemplateEngine implements TemplateEngine {
 
         @Override
         public Reader getReader(String name) throws IOException {
-            if (!name.endsWith(suffix)) {
-                name += suffix;
+            if (!name.endsWith(SUFFIX)) {
+                name += SUFFIX;
             }
 
             String fullPath = pathPrefix + name;

--- a/pippo-jaxb/src/main/java/ro/pippo/jaxb/JaxbInitializer.java
+++ b/pippo-jaxb/src/main/java/ro/pippo/jaxb/JaxbInitializer.java
@@ -16,8 +16,7 @@
 package ro.pippo.jaxb;
 
 import org.kohsuke.MetaInfServices;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import ro.pippo.core.Application;
 import ro.pippo.core.Initializer;
 
@@ -26,8 +25,6 @@ import ro.pippo.core.Initializer;
  */
 @MetaInfServices(Initializer.class)
 public class JaxbInitializer implements Initializer {
-
-    private static final Logger log = LoggerFactory.getLogger(JaxbInitializer.class);
 
     @Override
     public void init(Application application) {

--- a/pippo-pebble/src/main/java/ro/pippo/pebble/AngularJSExtension.java
+++ b/pippo-pebble/src/main/java/ro/pippo/pebble/AngularJSExtension.java
@@ -20,15 +20,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.mitchellbosecke.pebble.extension.AbstractExtension;
 import com.mitchellbosecke.pebble.extension.Function;
 
 public class AngularJSExtension extends AbstractExtension {
-
-    private static final Logger log = LoggerFactory.getLogger(AngularJSExtension.class);
 
     public AngularJSExtension() {
     }

--- a/pippo-pebble/src/main/java/ro/pippo/pebble/FormatTimeExtension.java
+++ b/pippo-pebble/src/main/java/ro/pippo/pebble/FormatTimeExtension.java
@@ -47,11 +47,13 @@ public class FormatTimeExtension extends AbstractExtension {
 
     public class FormatTimeFilter implements Filter {
 
+        private static final String EXISTING_FORMAT = "existingFormat";
+
         @Override
         public List<String> getArgumentNames() {
             List<String> names = new ArrayList<>();
             names.add("format");
-            names.add("existingFormat");
+            names.add(EXISTING_FORMAT);
             return names;
         }
 
@@ -64,8 +66,8 @@ public class FormatTimeExtension extends AbstractExtension {
             EvaluationContext context = (EvaluationContext) args.get("_context");
             Locale locale = context.getLocale();
 
-            DateFormat existingFormat = null;
-            DateFormat intendedFormat = null;
+            DateFormat existingFormat;
+            DateFormat intendedFormat;
 
             String format = (String) args.get("format");
             int type = parseStyle(format);
@@ -76,8 +78,8 @@ public class FormatTimeExtension extends AbstractExtension {
             }
 
             Date date;
-            if (args.get("existingFormat") != null) {
-                existingFormat = new SimpleDateFormat((String) args.get("existingFormat"), locale);
+            if (args.get(EXISTING_FORMAT) != null) {
+                existingFormat = new SimpleDateFormat((String) args.get(EXISTING_FORMAT), locale);
                 try {
                     date = existingFormat.parse((String) input);
                 } catch (ParseException e) {

--- a/pippo-pebble/src/main/java/ro/pippo/pebble/GlobalVariablesExtension.java
+++ b/pippo-pebble/src/main/java/ro/pippo/pebble/GlobalVariablesExtension.java
@@ -16,20 +16,12 @@
 package ro.pippo.pebble;
 
 import com.mitchellbosecke.pebble.extension.AbstractExtension;
-import com.mitchellbosecke.pebble.extension.Function;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class GlobalVariablesExtension extends AbstractExtension {
-
-    private static final Logger log = LoggerFactory.getLogger(GlobalVariablesExtension.class);
 
     private final Map<String, Object> globalVariables;
 

--- a/pippo-pebble/src/main/java/ro/pippo/pebble/I18nExtension.java
+++ b/pippo-pebble/src/main/java/ro/pippo/pebble/I18nExtension.java
@@ -23,8 +23,6 @@ import java.util.Map;
 
 import com.mitchellbosecke.pebble.extension.escaper.SafeString;
 import com.mitchellbosecke.pebble.template.EvaluationContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ro.pippo.core.Messages;
 
@@ -33,8 +31,6 @@ import com.mitchellbosecke.pebble.extension.AbstractExtension;
 import com.mitchellbosecke.pebble.extension.Function;
 
 public class I18nExtension extends AbstractExtension {
-
-    private static final Logger log = LoggerFactory.getLogger(I18nExtension.class);
 
     private final Messages messages;
 

--- a/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleInitializer.java
+++ b/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleInitializer.java
@@ -16,8 +16,6 @@
 package ro.pippo.pebble;
 
 import org.kohsuke.MetaInfServices;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ro.pippo.core.Application;
 import ro.pippo.core.Initializer;
@@ -27,8 +25,6 @@ import ro.pippo.core.Initializer;
  */
 @MetaInfServices(Initializer.class)
 public class PebbleInitializer implements Initializer {
-
-    private static final Logger log = LoggerFactory.getLogger(PebbleInitializer.class);
 
     @Override
     public void init(Application application) {

--- a/pippo-sasscompiler/src/main/java/ro/pippo/sasscompiler/SassResourceHandler.java
+++ b/pippo-sasscompiler/src/main/java/ro/pippo/sasscompiler/SassResourceHandler.java
@@ -17,8 +17,7 @@ package ro.pippo.sasscompiler;
 
 import com.vaadin.sass.internal.ScssContext;
 import com.vaadin.sass.internal.ScssStylesheet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import ro.pippo.core.PippoRuntimeException;
 import ro.pippo.core.route.ClasspathResourceHandler;
 import ro.pippo.core.route.RouteContext;
@@ -34,8 +33,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Daniel Jipa
  */
 public class SassResourceHandler extends ClasspathResourceHandler {
-
-    private static final Logger log = LoggerFactory.getLogger(SassResourceHandler.class);
 
     private boolean minify;
     private Map<String, String> sourceMap = new ConcurrentHashMap<>(); // cache


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1068 - Unused private fields should be removed.
squid:S1854 - Dead stores should be removed.
squid:S1192 - String literals should not be duplicated.
squid:S00115 - Constant names should comply with a naming convention.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S00115
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava