### PR TITLE
Make chunked transfer-encoding optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade [pippo-tomcat] to Tomcat 8.0.33
 - Upgrade [pippo-jade] to Jade 1.1.4
 - Upgrade [pippo-pebble] to Pebble 2.2.1
+- Make `chunked` transfer-encoding optional, not the default
 
 #### Added
 - [#245]: Route groups


### PR DESCRIPTION
By flushing the response buffer we force `chunked` transfer-encoding.  When we do this we lose the option to relay `Content-Length` to the client for `HEAD` requests or for setting-up client-side deterministic download progress indicators on `GET` requests.

This PR makes `chunked` transfer encoding optional and improves the `HEAD` response of the `DirectoryHandler`.