### PR TITLE
Workaround for Issue #273

### DIFF
--- a/pippo-jetty/src/main/java/ro/pippo/jetty/JettyServer.java
+++ b/pippo-jetty/src/main/java/ro/pippo/jetty/JettyServer.java
@@ -71,7 +71,7 @@ public class JettyServer extends AbstractWebServer<JettySettings> {
             String version = server.getClass().getPackage().getImplementationVersion();
             log.info("Starting Jetty Server {} on port {}", version, getSettings().getPort());
             server.start();
-            if (pippoSettings.isTest()) {
+            if (!pippoSettings.isTest()) {
                 server.join();
             }
         } catch (Exception e) {

--- a/pippo-jetty/src/main/java/ro/pippo/jetty/JettyServer.java
+++ b/pippo-jetty/src/main/java/ro/pippo/jetty/JettyServer.java
@@ -39,6 +39,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.concurrent.TimeUnit;
+import ro.pippo.core.RuntimeMode;
 
 /**
  * @author Decebal Suiu
@@ -71,7 +72,9 @@ public class JettyServer extends AbstractWebServer<JettySettings> {
             String version = server.getClass().getPackage().getImplementationVersion();
             log.info("Starting Jetty Server {} on port {}", version, getSettings().getPort());
             server.start();
-            server.join();
+            if (RuntimeMode.getCurrent() != RuntimeMode.TEST) {
+                server.join();
+            }
         } catch (Exception e) {
             throw new PippoRuntimeException(e);
         }

--- a/pippo-jetty/src/main/java/ro/pippo/jetty/JettyServer.java
+++ b/pippo-jetty/src/main/java/ro/pippo/jetty/JettyServer.java
@@ -39,7 +39,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.concurrent.TimeUnit;
-import ro.pippo.core.RuntimeMode;
 
 /**
  * @author Decebal Suiu
@@ -72,7 +71,7 @@ public class JettyServer extends AbstractWebServer<JettySettings> {
             String version = server.getClass().getPackage().getImplementationVersion();
             log.info("Starting Jetty Server {} on port {}", version, getSettings().getPort());
             server.start();
-            if (RuntimeMode.getCurrent() != RuntimeMode.TEST) {
+            if (pippoSettings.isTest()) {
                 server.join();
             }
         } catch (Exception e) {

--- a/pippo-tomcat/src/main/java/ro/pippo/tomcat/TomcatServer.java
+++ b/pippo-tomcat/src/main/java/ro/pippo/tomcat/TomcatServer.java
@@ -90,7 +90,7 @@ public class TomcatServer extends AbstractWebServer<TomcatSettings> {
         } catch (LifecycleException e) {
             throw new PippoRuntimeException(e);
         }
-        if (RuntimeMode.getCurrent() != RuntimeMode.TEST) {
+        if (pippoSettings.isTest()) {
             tomcat.getServer().await();
         }
     }

--- a/pippo-tomcat/src/main/java/ro/pippo/tomcat/TomcatServer.java
+++ b/pippo-tomcat/src/main/java/ro/pippo/tomcat/TomcatServer.java
@@ -33,6 +33,7 @@ import ro.pippo.core.WebServer;
 import ro.pippo.core.util.StringUtils;
 
 import java.io.File;
+import ro.pippo.core.RuntimeMode;
 
 /**
  * @author Daniel Jipa
@@ -89,7 +90,9 @@ public class TomcatServer extends AbstractWebServer<TomcatSettings> {
         } catch (LifecycleException e) {
             throw new PippoRuntimeException(e);
         }
-        tomcat.getServer().await();
+        if (RuntimeMode.getCurrent() != RuntimeMode.TEST) {
+            tomcat.getServer().await();
+        }
     }
 
     private void enablePlainConnector(Tomcat tomcat) {
@@ -109,7 +112,7 @@ public class TomcatServer extends AbstractWebServer<TomcatSettings> {
         connector.setAttribute("keystoreFile", getSettings().getKeystoreFile());
         connector.setAttribute("clientAuth", getSettings().getClientAuth());
         if (getSettings().getClientAuth()) {
-        	connector.setAttribute("truststoreFile", getSettings().getTruststoreFile());
+            connector.setAttribute("truststoreFile", getSettings().getTruststoreFile());
             connector.setAttribute("truststorePass", getSettings().getTruststorePassword());
         }
         connector.setAttribute("protocol", "HTTP/1.1");

--- a/pippo-tomcat/src/main/java/ro/pippo/tomcat/TomcatServer.java
+++ b/pippo-tomcat/src/main/java/ro/pippo/tomcat/TomcatServer.java
@@ -33,7 +33,6 @@ import ro.pippo.core.WebServer;
 import ro.pippo.core.util.StringUtils;
 
 import java.io.File;
-import ro.pippo.core.RuntimeMode;
 
 /**
  * @author Daniel Jipa
@@ -90,7 +89,7 @@ public class TomcatServer extends AbstractWebServer<TomcatSettings> {
         } catch (LifecycleException e) {
             throw new PippoRuntimeException(e);
         }
-        if (pippoSettings.isTest()) {
+        if (!pippoSettings.isTest()) {
             tomcat.getServer().await();
         }
     }


### PR DESCRIPTION
Hello

I investigated about `server.join();` from the `JettyServer.start()` and `tomcat.getServer().await();` from the `TomcatServer.start()`

In both cases the methods call [Thread.join()](http://docs.oracle.com/javase/1.5.0/docs/api/java/lang/Thread.html#join%28%29) and block the main thread of JUnit until the web server thread stops and release the main thread.

I searched how to make JUnit not work on the main thread, but I found nothing that would serve
I tried [this](http://www.codeaffine.com/2014/07/21/a-junit-rule-to-run-a-test-in-its-own-thread/) and [this](http://falutin.net/2012/12/30/multithreaded-testing-with-junit/)

We must not comment `server.join();` or `tomcat.getServer().await();` because as [AlexR](http://stackoverflow.com/questions/15924874/embedded-jetty-why-to-use-join) says:

> `join()` is blocking until server is ready. It behaves like Thread.join() and indeed calls join() of Jetty's thread pool. Everything works without this because jetty starts very quickly. However if your application is heavy enough the start might take some time. Call of `join()` guarantees that after it the server is indeed ready.

My final solution it's a workaround

**JettyServer.start()**
```java
if (RuntimeMode.getCurrent() != RuntimeMode.TEST) {
    server.join();
}
```
**TomcatServer.start()**
```java
if (RuntimeMode.getCurrent() != RuntimeMode.TEST) {
    tomcat.getServer().await();
}
```

According to many examples I saw on StackOverflow, in the case of JUnit you have to avoid `server.join();` and as [Joakim](http://stackoverflow.com/questions/19113359/sending-request-to-the-newly-created-jetty-server-for-testing-purposes) says is not needed for unit testing. 

But I'm no expert in JUnit, I do not know what consequences might have
