### PR TITLE
Updated Pippo Session to JDK8

### DIFF
--- a/pippo-session-cookie/src/main/java/ro/pippo/session/cookie/CookieSessionDataStorage.java
+++ b/pippo-session-cookie/src/main/java/ro/pippo/session/cookie/CookieSessionDataStorage.java
@@ -15,6 +15,8 @@
  */
 package ro.pippo.session.cookie;
 
+import ro.pippo.session.SerializationSessionDataTranscoder;
+import ro.pippo.session.SessionDataTranscoder;
 import ro.pippo.core.Request;
 import ro.pippo.core.Response;
 import ro.pippo.core.util.CookieUtils;

--- a/pippo-session/src/main/java/ro/pippo/session/SessionDataTranscoder.java
+++ b/pippo-session/src/main/java/ro/pippo/session/SessionDataTranscoder.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ro.pippo.session.cookie;
-
-import ro.pippo.session.SessionData;
+package ro.pippo.session;
 
 /**
  * By default <code>CookieSessionDataStorage</code> uses Java's serialization to serialize session data


### PR DESCRIPTION
-Use [Base64](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html) JDK 8
-Use [Try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) JDK 7
-Move SessionDataTranscoder and SerializationSessionDataTranscoder to Pippo-Session to be used by other session modules that require