### PR TITLE
Support for websockets

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/Application.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Application.java
@@ -34,6 +34,7 @@ import ro.pippo.core.route.WebjarsResourceHandler;
 import ro.pippo.core.util.HttpCacheToolkit;
 import ro.pippo.core.util.MimeTypes;
 import ro.pippo.core.util.ServiceLocator;
+import ro.pippo.core.websocket.WebSocketHandler;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -73,6 +74,8 @@ public class Application {
 
     private Map<String, Object> locals;
 
+    private Map<String, WebSocketHandler> webSocketHandlers;
+
     public Application() {
         this(new PippoSettings(RuntimeMode.getCurrent()));
     }
@@ -85,6 +88,7 @@ public class Application {
         this.httpCacheToolkit = new HttpCacheToolkit(settings);
         this.engines = new ContentTypeEngines();
         this.initializers = new ArrayList<>();
+        this.webSocketHandlers = new HashMap<>();
 
         registerContentTypeEngine(TextPlainEngine.class);
     }
@@ -275,6 +279,14 @@ public class Application {
 
     public void addRouteGroup(RouteGroup routeGroup) {
         getRouter().addRouteGroup(routeGroup);
+    }
+
+    public void addWebSocket(String path, WebSocketHandler webSocketHandler) {
+        webSocketHandlers.put(path, webSocketHandler);
+    }
+
+    public WebSocketHandler getWebSocketHandler(String path) {
+        return webSocketHandlers.get(path);
     }
 
     /**

--- a/pippo-core/src/main/java/ro/pippo/core/Pippo.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Pippo.java
@@ -91,14 +91,7 @@ public class Pippo {
      */
     public static Pippo send(final String text) {
         Pippo pippo = new Pippo();
-        pippo.getApplication().GET("/", new RouteHandler() {
-
-            @Override
-            public void handle(RouteContext routeContext) {
-                routeContext.send(text);
-            }
-
-        });
+        pippo.getApplication().GET("/", (routeContext) -> routeContext.send(text));
         pippo.start();
 
         return pippo;

--- a/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
@@ -137,8 +137,7 @@ public class PippoFilter implements Filter {
 
         log.debug("Request {} '{}'", request.getMethod(), requestPath);
 
-        // dispatch route(s)
-        routeDispatcher.dispatch(request, response);
+        processRequest(request, response);
     }
 
     public Application getApplication() {
@@ -160,6 +159,11 @@ public class PippoFilter implements Filter {
                 application = null;
             }
         }
+    }
+
+    protected void processRequest(Request request, Response response) throws IOException, ServletException {
+        // dispatch route(s)
+        routeDispatcher.dispatch(request, response);
     }
 
     private boolean shouldIgnorePath(String requestUri) {

--- a/pippo-core/src/main/java/ro/pippo/core/Request.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Request.java
@@ -76,7 +76,7 @@ public final class Request {
         initParameters();
 
         // empty path parameters for now (see setPathParameters method)
-        pathParameters = Collections.unmodifiableMap(new HashMap<String, ParameterValue>());
+        pathParameters = Collections.unmodifiableMap(new HashMap<>());
 
         // init all parameters
         initAllParameters();
@@ -415,6 +415,10 @@ public final class Request {
 
     public String getHeader(String name) {
         return httpServletRequest.getHeader(name);
+    }
+
+    public Enumeration<String> getHeaders(String name) {
+        return httpServletRequest.getHeaders(name);
     }
 
     public boolean isSecure() {

--- a/pippo-core/src/main/java/ro/pippo/core/websocket/AbstractWebSocketFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/websocket/AbstractWebSocketFilter.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.websocket;
+
+import ro.pippo.core.PippoFilter;
+import ro.pippo.core.Request;
+import ro.pippo.core.Response;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+/**
+ * @author Decebal Suiu
+ */
+public abstract class AbstractWebSocketFilter extends PippoFilter {
+
+    @Override
+    protected void processRequest(Request request, Response response) throws IOException, ServletException {
+        if (!acceptWebSocket(request, response)) {
+            super.processRequest(request, response);
+        }
+    }
+
+    protected boolean acceptWebSocket(Request request, Response response)
+        throws IOException, ServletException {
+        // information required to send the server handshake message
+        if (!headerContainsToken(request, "Upgrade", "websocket")) {
+            return false;
+        }
+
+        if (!headerContainsToken(request, "Connection", "upgrade")) {
+            response.badRequest().commit();
+            return false;
+        }
+
+        if (!headerContainsToken(request, "Sec-websocket-version", "13")) {
+            response.badRequest().header("Sec-WebSocket-Version", "13"); // http://tools.ietf.org/html/rfc6455#section-4.4
+            return false;
+        }
+
+        String key = request.getHeader("Sec-WebSocket-Key");
+        if (key == null) {
+            response.badRequest().commit();
+            return false;
+        }
+
+        String origin = request.getHeader("Origin");
+        if (!verifyOrigin(origin)) {
+            response.forbidden().commit();
+            return false;
+        }
+
+        String subProtocol = null;
+        List<String> subProtocols = getTokensFromHeader(request, "Sec-WebSocket-Protocol-Client");
+        if (!subProtocols.isEmpty()) {
+            subProtocol = selectSubProtocol(subProtocols);
+        }
+
+        if (subProtocol != null) {
+            response.header("Sec-WebSocket-Protocol", subProtocol);
+        }
+
+        return true;
+    }
+
+    /*
+     * This only works for tokens. Quoted strings need more sophisticated parsing.
+     */
+    private boolean headerContainsToken(Request request, String headerName, String target) {
+        Enumeration<String> headers = request.getHeaders(headerName);
+        while (headers.hasMoreElements()) {
+            String header = headers.nextElement();
+            String[] tokens = header.split(",");
+            for (String token : tokens) {
+                if (target.equalsIgnoreCase(token.trim())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /*
+     * This only works for tokens. Quoted strings need more sophisticated parsing.
+     */
+    protected List<String> getTokensFromHeader(Request request, String headerName) {
+        List<String> result = new ArrayList<>();
+
+        Enumeration<String> headers = request.getHeaders(headerName);
+        while (headers.hasMoreElements()) {
+            String header = headers.nextElement();
+            String[] tokens = header.split(",");
+            for (String token : tokens) {
+                result.add(token.trim());
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Intended to be overridden by sub-classes that wish to verify the origin
+     * of a WebSocket request before processing it.
+     */
+    protected boolean verifyOrigin(String origin) {
+        return true;
+    }
+
+    /**
+     * Intended to be overridden by sub-classes that wish to select a
+     * sub-protocol if the client provides a list of supported protocols.
+     */
+    protected String selectSubProtocol(List<String> subProtocols) {
+        return null;
+    }
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketConnection.java
+++ b/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketConnection.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.websocket;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+/**
+ * @author Decebal Suiu
+ */
+public interface WebSocketConnection {
+
+    /**
+     * @return {@code true} when the underlying native web socket connection is still open.
+     */
+    boolean isOpen();
+
+    /**
+     * Closes the underlying web socket connection.
+     */
+    void close(int code, String reason);
+
+    /**
+     * Sends a text message to the client.
+     *
+     * @return {@code this} object, for chaining methods
+     * @throws IOException when an IO error occurs during the write to the client
+     */
+    WebSocketConnection sendMessage(String message) throws IOException;
+
+    /**
+     * Sends a binary message to the client.
+     *
+     * @return {@code this} object, for chaining methods
+     * @throws IOException when an IO error occurs during the write to the client
+     */
+    WebSocketConnection sendMessage(byte[] message, int offset, int length) throws IOException;
+
+    InetSocketAddress getRemoteAddress();
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketContext.java
+++ b/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.websocket;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * @author Decebal Suiu
+ */
+public class WebSocketContext {
+
+    private final WebSocketConnection connection;
+    private final List<WebSocketConnection> connections;
+
+    public WebSocketContext(List<WebSocketConnection> connections, WebSocketConnection connection) {
+        this.connections = connections;
+        this.connection = connection;
+    }
+
+    public WebSocketConnection getConnection() {
+        return connection;
+    }
+
+    public void sendMessage(String message) throws IOException {
+        connection.sendMessage(message);
+    }
+
+    public void broadcastMessage(String message) throws IOException {
+        for (WebSocketConnection connection : connections) {
+            connection.sendMessage(message);
+        }
+    }
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketHandler.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.websocket;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Decebal Suiu
+ */
+public interface WebSocketHandler {
+
+    Logger log = LoggerFactory.getLogger(WebSocketHandler.class);
+
+    /**
+     * Called when a text message arrives from the client.
+     *
+     * @param message
+     *      the text message from the client
+     */
+    void onMessage(WebSocketConnection connection, final String message);
+
+    /**
+     * Called when a binary message arrives from the client.
+     *
+     * @param data
+     *      the binary message from the client
+     * @param offset
+     *      the offset to read from
+     * @param length
+     *      how much data to read
+     */
+    default void onMessage(WebSocketConnection connection, byte[] data, int offset, int length) {
+        // do nothing
+    }
+
+    /**
+     * A client successfully has made a web socket connection.
+     *
+     * @param connection
+     *      the web socket connection to use to communicate with the client
+     */
+    default void onOpen(WebSocketConnection connection) {
+        log.debug("Open websocket connection");
+    }
+
+    /**
+     * A notification after the close of the web socket connection.
+     * The connection could be closed by either the client or the server
+     *
+     * @param closeCode
+     * @param message
+     */
+    default void onClose(WebSocketConnection connection, int closeCode, String message) {
+        log.debug("Close websocket connection");
+    }
+
+    /**
+     * A notification that the web socket does not receive any message for the specified timeout period.
+     */
+    default void onTimeout(WebSocketConnection connection) {
+        log.debug("Timeout websocket connection");
+    }
+
+    /**
+     * A notification after a communication error.
+     *
+     * @param t
+     *      The throwable for the communication problem
+     */
+    default void onError(WebSocketConnection connection, Throwable t) {
+        log.error("Error websocket", t);
+    }
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketHandler.java
@@ -31,7 +31,7 @@ public interface WebSocketHandler {
      * @param message
      *      the text message from the client
      */
-    void onMessage(WebSocketConnection connection, final String message);
+    void onMessage(WebSocketContext webSocketContext, final String message);
 
     /**
      * Called when a binary message arrives from the client.
@@ -43,7 +43,7 @@ public interface WebSocketHandler {
      * @param length
      *      how much data to read
      */
-    default void onMessage(WebSocketConnection connection, byte[] data, int offset, int length) {
+    default void onMessage(WebSocketContext webSocketContext, byte[] data, int offset, int length) {
         // do nothing
     }
 
@@ -53,7 +53,7 @@ public interface WebSocketHandler {
      * @param connection
      *      the web socket connection to use to communicate with the client
      */
-    default void onOpen(WebSocketConnection connection) {
+    default void onOpen(WebSocketContext webSocketContext) {
         log.debug("Open websocket connection");
     }
 
@@ -64,14 +64,14 @@ public interface WebSocketHandler {
      * @param closeCode
      * @param message
      */
-    default void onClose(WebSocketConnection connection, int closeCode, String message) {
+    default void onClose(WebSocketContext webSocketContext, int closeCode, String message) {
         log.debug("Close websocket connection");
     }
 
     /**
      * A notification that the web socket does not receive any message for the specified timeout period.
      */
-    default void onTimeout(WebSocketConnection connection) {
+    default void onTimeout(WebSocketContext webSocketContext) {
         log.debug("Timeout websocket connection");
     }
 
@@ -81,7 +81,7 @@ public interface WebSocketHandler {
      * @param t
      *      The throwable for the communication problem
      */
-    default void onError(WebSocketConnection connection, Throwable t) {
+    default void onError(WebSocketContext webSocketContext, Throwable t) {
         log.error("Error websocket", t);
     }
 

--- a/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketProcessor.java
+++ b/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketProcessor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.websocket;
+
+/**
+ * @author Decebal Suiu
+ */
+public interface WebSocketProcessor {
+
+    /**
+     * Called when a text message arrives from the client.
+     *
+     * @param message
+     *      the text message from the client
+     */
+    void onMessage(final String message);
+
+    /**
+     * Called when a binary message arrives from the client.
+     *
+     * @param data
+     *      the binary message from the client
+     * @param offset
+     *      the offset to read from
+     * @param length
+     *      how much data to read
+     */
+    void onMessage(byte[] data, int offset, int length);
+
+    /**
+     * A client successfully has made a web socket connection.
+     *
+     * @param containerConnection
+     *      the web socket connection to use to communicate with the client
+     */
+    void onOpen(Object containerConnection);
+
+    /**
+     * A notification after the close of the web socket connection.
+     * The connection could be closed by either the client or the server
+     *
+     * @param closeCode
+     * @param message
+     */
+    void onClose(int closeCode, String message);
+
+    /**
+     * A notification after a communication error.
+     *
+     * @param t
+     *      The throwable for the communication problem
+     */
+    void onError(Throwable t);
+
+}

--- a/pippo-jetty/pom.xml
+++ b/pippo-jetty/pom.xml
@@ -42,13 +42,17 @@
             <artifactId>jetty-annotations</artifactId>
             <version>${jetty.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/pippo-jetty/src/main/java/ro/pippo/jetty/websocket/JettyWebSocketConnection.java
+++ b/pippo-jetty/src/main/java/ro/pippo/jetty/websocket/JettyWebSocketConnection.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.jetty.websocket;
+
+import org.eclipse.jetty.websocket.api.Session;
+import ro.pippo.core.websocket.WebSocketConnection;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+/**
+ * @author Decebal Suiu
+ */
+public class JettyWebSocketConnection implements WebSocketConnection {
+
+    private final Session session;
+
+    public JettyWebSocketConnection(Session session) {
+        this.session = session;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return session.isOpen();
+    }
+
+    @Override
+    public void close(int code, String reason) {
+        if (isOpen()) {
+            session.close(code, reason);
+        }
+    }
+
+    @Override
+    public WebSocketConnection sendMessage(String message) throws IOException {
+        checkClosed();
+
+        session.getRemote().sendString(message);
+
+        return this;
+    }
+
+    @Override
+    public WebSocketConnection sendMessage(byte[] message, int offset, int length) throws IOException {
+        checkClosed();
+
+        ByteBuffer buffer = ByteBuffer.wrap(message, offset, length);
+        session.getRemote().sendBytes(buffer);
+
+        return this;
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() {
+        return session.getRemoteAddress();
+    }
+
+    public Session getSession() {
+        return session;
+    }
+
+    private void checkClosed() {
+        if (!isOpen()) {
+            throw new IllegalStateException("The connection is closed.");
+        }
+    }
+
+}

--- a/pippo-jetty/src/main/java/ro/pippo/jetty/websocket/JettyWebSocketFilter.java
+++ b/pippo-jetty/src/main/java/ro/pippo/jetty/websocket/JettyWebSocketFilter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.jetty.websocket;
+
+import org.eclipse.jetty.websocket.api.WebSocketPolicy;
+import org.eclipse.jetty.websocket.server.WebSocketServerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ro.pippo.core.Request;
+import ro.pippo.core.Response;
+import ro.pippo.core.websocket.AbstractWebSocketFilter;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+/**
+ * @author Decebal Suiu
+ */
+public class JettyWebSocketFilter extends AbstractWebSocketFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(JettyWebSocketFilter.class);
+
+    private WebSocketServerFactory webSocketFactory;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        super.init(filterConfig);
+
+        try {
+            WebSocketPolicy serverPolicy = WebSocketPolicy.newServerPolicy();
+
+            String inputBufferSize = filterConfig.getInitParameter("inputBufferSize");
+            if (inputBufferSize != null) {
+                serverPolicy.setInputBufferSize(Integer.parseInt(inputBufferSize));
+            }
+
+            String idleTimeout = filterConfig.getInitParameter("idleTimeout");
+            if (idleTimeout != null) {
+                serverPolicy.setIdleTimeout(Integer.parseInt(idleTimeout));
+            }
+
+            String maxTextMessageSize = filterConfig.getInitParameter("maxTextMessageSize");
+            if (maxTextMessageSize != null) {
+                serverPolicy.setMaxTextMessageSize(Integer.parseInt(maxTextMessageSize));
+            }
+
+            webSocketFactory = new WebSocketServerFactory(serverPolicy);
+            webSocketFactory.setCreator((req, resp) -> new JettyWebSocketProcessor(req, resp, getApplication()));
+            webSocketFactory.start();
+        } catch (ServletException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        if (webSocketFactory != null) {
+            try {
+                webSocketFactory.stop();
+            } catch (Exception e) {
+                log.warn("A problem occurred while stopping the web socket factory", e);
+            }
+        }
+
+        super.destroy();
+    }
+
+    @Override
+    protected boolean acceptWebSocket(Request request, Response response) throws IOException, ServletException {
+        return super.acceptWebSocket(request, response) && webSocketFactory
+            .acceptWebSocket(request.getHttpServletRequest(), response.getHttpServletResponse());
+    }
+
+}

--- a/pippo-jetty/src/main/java/ro/pippo/jetty/websocket/JettyWebSocketProcessor.java
+++ b/pippo-jetty/src/main/java/ro/pippo/jetty/websocket/JettyWebSocketProcessor.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.jetty.websocket;
+
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketListener;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ro.pippo.core.Application;
+import ro.pippo.core.util.StringUtils;
+import ro.pippo.core.websocket.WebSocketConnection;
+import ro.pippo.core.websocket.WebSocketHandler;
+import ro.pippo.core.websocket.WebSocketProcessor;
+
+import java.net.SocketTimeoutException;
+
+/**
+ * @author Decebal Suiu
+ */
+public class JettyWebSocketProcessor implements WebSocketProcessor, WebSocketListener {
+
+    private static final Logger log = LoggerFactory.getLogger(JettyWebSocketProcessor.class);
+
+//    private final List<WebSocketConnection> connections; // used by WebSocketConnection.broadcastMessage(String message)
+    private final WebSocketHandler handler;
+
+    private WebSocketConnection connection;
+
+    public JettyWebSocketProcessor(ServletUpgradeRequest req, ServletUpgradeResponse resp, Application application) {
+//        this.connections = new CopyOnWriteArrayList<>();
+
+        // TODO: make this outside ?!
+        // init path
+        String applicationPath = application.getRouter().getContextPath();
+        String requestUri = req.getRequestPath();
+        String path = applicationPath.isEmpty() ? requestUri : requestUri.substring(applicationPath.length());
+        if (StringUtils.isNullOrEmpty(path)) {
+            path = "/";
+        }
+
+        handler = application.getWebSocketHandler(path);
+    }
+
+    @Override
+    public void onMessage(String message) {
+        handler.onMessage(connection, message);
+    }
+
+    @Override
+    public void onMessage(byte[] data, int offset, int length) {
+        handler.onMessage(connection, data, offset, length);
+    }
+
+    @Override
+    public void onOpen(Object connection) {
+        if (!(connection instanceof Session)) {
+            throw new IllegalArgumentException(getClass().getName() + " can work only with " + Session.class.getName());
+        }
+
+        onWebSocketConnect((Session) connection);
+    }
+
+    @Override
+    public void onClose(int closeCode, String message) {
+        // TODO
+//        connections.remove();
+        handler.onClose(connection, closeCode, message);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        // TODO
+        handler.onError(connection, t);
+    }
+
+    @Override
+    public void onWebSocketBinary(byte[] payload, int offset, int len) {
+        onMessage(payload, offset, len);
+    }
+
+    @Override
+    public void onWebSocketText(String message) {
+        onMessage(message);
+    }
+
+    @Override
+    public void onWebSocketClose(int statusCode, String reason) {
+        onClose(statusCode, reason);
+    }
+
+    @Override
+    public void onWebSocketConnect(Session session) {
+        connection = new JettyWebSocketConnection(session);
+        onConnect(connection);
+    }
+
+    @Override
+    public void onWebSocketError(Throwable cause) {
+
+        if (cause instanceof SocketTimeoutException) {
+            handler.onTimeout(connection);
+        } else {
+            log.error("An error occurred when using WebSocket.", cause);
+            onError(cause);
+        }
+    }
+
+    protected final void onConnect(WebSocketConnection connection) {
+//        connections.add(connection);
+    }
+
+}


### PR DESCRIPTION
This is a functional POC/Draft for  #275 .

I will start with a tiny demo (echo application using websocket). 

First, in the `Application` class I added a new method with the signature:

``` java
public void addWebSocket(String path, WebSocketHandler webSocketHandler);
```

`WebSocketHandler` is an interface (functional) that contains one method 

``` java
void onMessage(WebSocketContext webSocketContext, String message);
```

and some default methods.

To add an echo based on websocket I must write:

``` java
// add web socket
addWebSocket("/ws/echo", (webSocketContext, message) -> {
    try {
        webSocketContext.sendMessage(message);
    } catch (IOException e) {
        e.printStackTrace();
    }
});
```

If you need more control you can override other methods available in `WebSocketHandler`:

``` java
addWebSocket("/ws/echo", new WebSocketHandler() {

    @Override
    public void onMessage(WebSocketContext webSocketContext, String message) {
        System.out.println("TestWebSocket.onMessage");
        System.out.println("message = " + message);
        try {
            webSocketContext.sendMessage(message);
        } catch (IOException e) {
            e.printStackTrace();
        }
    }

    @Override
    public void onMessage(WebSocketContext webSocketContext, byte[] data, int offset, int length) {
        System.out.println("TestWebSocket.onMessage");
    }

    @Override
    public void onOpen(WebSocketContext webSocketContext) {
        System.out.println("TestWebSocket.onOpen");
    }

    @Override
    public void onClose(WebSocketContext webSocketContext, int closeCode, String message) {
        System.out.println("TestWebSocket.onClose");
    }

    @Override
    public void onTimeout(WebSocketContext webSocketContext) {
        System.out.println("TestWebSocket.onTimeout");
    }

    @Override
    public void onError(WebSocketContext webSocketContext, Throwable t) {
        System.out.println("TestWebSocket.onError");
    }

});
```

I use a standard `Route` to serve the `index.html` file that contains the script block with the websocket client side:

``` java
GET("/", (routeContext) -> {
    try {
        routeContext.send(IoUtils.toString(TestWebSocket.class.getResourceAsStream("/index.html")));
    } catch (IOException e) {
        e.printStackTrace();
    }
});

// OR

DirectoryHandler directoryHandler = new DirectoryHandler("/", new File("src/main/resources"));
GET(directoryHandler.getUriPattern(), directoryHandler);
```

The content of `index.html` file is:

``` html
<!DOCTYPE html>
<html>
    <head>
        <title>Echo WebSocket</title>
        <meta charset="UTF-8">
        <meta name="viewport" content="width=device-width">
    </head>

    <body>
         <input id="message-box" autofocus onkeypress="send(event)"/>

        <!-- server responses get written here -->
        <div id="messages"></div>

        <!-- script to utilise the WebSocket -->
        <script type="text/javascript">

            var messages = document.getElementById("messages");

            // create a new instance of the webSocket
            var webSocket = new WebSocket("ws://localhost:8338/ws/echo");

            webSocket.onopen = function() {
                writeResponse("Connection opened!");
            };

            webSocket.onmessage = function(evt) {
                writeResponse(evt.data);
            };

            webSocket.onclose = function() {
                writeResponse("Connection closed!");
            };

            /**
             * Sends the value of the text input to the server
             */
            function send(evt) {
                // check for ENTER key pressed
                if (evt.keyCode != 13) {
                    return;
                }

                var messageBox = document.getElementById("message-box");

                // read the text from the message box and send it to server via websocket
                webSocket.send(messageBox.value);

                // clear the message box
                messageBox.value = "";
            }

            function writeResponse(text) {
                messages.innerHTML += "<br/>" + text;
            }

        </script>
    </body>
</html>
```

The last step is to "inject" the `WebSocketFilter` in the Pippo launcher:

``` java
 Pippo pippo = new Pippo() {

    /*
     * Change PippoFilter with a subclass that enables WebSocket
     */
    @Override
    protected PippoFilter createPippoFilter(Application application) {
        PippoFilter pippoFilter = new JettyWebSocketFilter();
        pippoFilter.setApplication(application);

        return pippoFilter;
    }

};
```

I must admit that I don't like this manual approach but for the moment is OK. Probably the correct approach is to detect if the application contains websocket routes and only in this situation we must change automatically the `PippoFilter` with `WebSocketFilter`.

This PR comes with:
- the new `websocket` package in `pippo-core` (contains only three tiny interface and an abstract class)
- the websocket support for `JettyServer` (`pippo-jetty` module)

Below I will add some implementation details.
First, I think it's easy to add support for Undertow and Tomcat. We must implement `WebSocketFilter`, `WebSocketConnection` and `WebSocketProcessor` for each server.

I added an useful `AbstractWebSocketFilter` that contains common logic for all websocket filters.
Were two option related to how to "inject" the websocket in Server:
- create `WebSocketFilte`r that extends `PippoFilter`
- modify each WebServer implementation

I chose the first variant because I can use the new created filter in `web.xml`. With variant two, the websocket support is available only for applications that use Pippo with an embedded web server. 

TODO:
- [ ] inject WebSocketFilter automatically in Pippo launcher
- [ ] use `uriPattern` as first parameter in Application.addWebSocket; now it's not possible to pass query parameters to websocket; the `path` parameter is static. My idea to resolve this task is to extract from DefaultRouter the part that read the parameters from a Request in a separate class - the DefaultRouter class s a little big so Single Responsability pattern for this class is welcome
- [x] add `WebSocketContext.broadcastMessage()`, for this we must register/unregister all WebSocketConnection(via `onOpen` and `onClose` methods) in a list

Any advice, question is welcome.
