### PR TITLE
Verify that starting server does not block

### DIFF
--- a/pippo-server-parent/pippo-jetty/pom.xml
+++ b/pippo-server-parent/pippo-jetty/pom.xml
@@ -48,6 +48,12 @@
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/pippo-server-parent/pippo-jetty/src/test/java/ro/pippo/jetty/JettyServerTest.java
+++ b/pippo-server-parent/pippo-jetty/src/test/java/ro/pippo/jetty/JettyServerTest.java
@@ -1,0 +1,40 @@
+package ro.pippo.jetty;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import ro.pippo.core.Application;
+import ro.pippo.core.Pippo;
+import ro.pippo.core.PippoSettings;
+import ro.pippo.core.RuntimeMode;
+
+
+public class JettyServerTest {
+    @Rule
+    public TestRule globalTimeout = new Timeout(1000);
+
+    @Test
+    public void testStartInTest() {
+        startPippo(RuntimeMode.TEST);
+    }
+
+    @Test
+    public void testStartInProd() {
+        startPippo(RuntimeMode.PROD);
+    }
+
+    private static void startPippo(final RuntimeMode runtimeMode) {
+        Pippo pippo = null;
+
+        try {
+            final PippoSettings pippoSettings = new PippoSettings(runtimeMode);
+            pippo = new Pippo(new Application(pippoSettings));
+            pippo.start();
+        } finally {
+            if (pippo != null) {
+                pippo.stop();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Suggested tests for #293.

I didn't add the tests for the other backend types, but ideally, all `WebServer` implementations should have the same behavior.