### PR TITLE
Reduce DirectoryHandler logging noise for normal IOExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade [pippo-pebble] to Pebble 2.2.2
 - Make `chunked` transfer-encoding optional, not the default
 - Make the text/plain content type engine handle returning reasonable types like String, CharSequence, char[], and byte[]
+- Reduce the DirectoryHandler logging noise caused by connection resets, broken pipes, and connection timeouts by not logging the IOException stacktrace
 
 #### Added
 - [#245]: Route groups

--- a/pippo-core/src/main/java/ro/pippo/core/route/DirectoryHandler.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/DirectoryHandler.java
@@ -259,6 +259,14 @@ public class DirectoryHandler implements RouteHandler {
             } else {
                 sendResource(resourceUrl, routeContext);
             }
+        } catch (IOException e) {
+            String message = e.getMessage();
+            if (!StringUtils.isNullOrEmpty(message)) {
+                log.warn("Error sending resource {} to {}: {}",
+                    resourceUrl, routeContext.getRequest().getClientIp(), message);
+            } else {
+                throw new PippoRuntimeException(e, "Failed to stream resource {}", resourceUrl);
+            }
         } catch (Exception e) {
             throw new PippoRuntimeException(e, "Failed to stream resource {}", resourceUrl);
         }


### PR DESCRIPTION
Normal behaviors like `connection reset by peer`, `broken pipe`, and `connection timed out` **with** their stacktrace clog the logs with useless information.  Instead log the IOException message, if available, with metadata about the request.