### PR TITLE
Improve the route group concept

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/Application.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Application.java
@@ -18,6 +18,7 @@ package ro.pippo.core;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.route.DefaultRouter;
+import ro.pippo.core.route.ResourceRouting;
 import ro.pippo.core.route.Route;
 import ro.pippo.core.route.Routing;
 import ro.pippo.core.route.RouteContext;
@@ -42,7 +43,7 @@ import java.util.Map;
  *
  * @author Decebal Suiu
  */
-public class Application implements Routing {
+public class Application implements ResourceRouting {
 
     private static final Logger log = LoggerFactory.getLogger(Application.class);
 

--- a/pippo-core/src/main/java/ro/pippo/core/Pippo.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Pippo.java
@@ -17,15 +17,15 @@ package ro.pippo.core;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ro.pippo.core.route.ResourceRouting;
 import ro.pippo.core.route.Route;
 import ro.pippo.core.route.RouteGroup;
-import ro.pippo.core.route.Routing;
 import ro.pippo.core.util.ServiceLocator;
 
 /**
  * @author Decebal Suiu
  */
-public class Pippo implements Routing {
+public class Pippo implements ResourceRouting {
 
     private static final Logger log = LoggerFactory.getLogger(Pippo.class);
 

--- a/pippo-core/src/main/java/ro/pippo/core/route/ResourceRouting.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/ResourceRouting.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.route;
+
+import java.io.File;
+
+/**
+ * An extension of <@link>Routing</@link> that add support for <@code>Resource</@code>.
+ *
+ * @author Decebal Suiu
+ */
+public interface ResourceRouting extends Routing {
+
+    /**
+     * It's a shortcut for {@link #addPublicResourceRoute(String)} with parameter <code>"/public"</code>.
+     */
+    default Route addPublicResourceRoute() {
+        return addPublicResourceRoute("/public");
+    }
+
+    /**
+     * Add a route that serves resources from the "public" directory within your classpath.
+     */
+    default Route addPublicResourceRoute(String urlPath) {
+        return addResourceRoute(new PublicResourceHandler(urlPath));
+    }
+
+    /**
+     * Add a route that serves resources from a directory(file system).
+     */
+    default Route addFileResourceRoute(String urlPath, File directory) {
+        return addResourceRoute(new FileResourceHandler(urlPath, directory));
+    }
+
+    default Route addFileResourceRoute(String urlPath, String directory) {
+        return addResourceRoute(new FileResourceHandler(urlPath, directory));
+    }
+
+    default Route addClasspathResourceRoute(String urlPath, Class<?> resourceClass) {
+        return addResourceRoute(new ClasspathResourceHandler(urlPath, resourceClass.getName().replace(".", "/")));
+    }
+
+    /**
+     * Add a route that serves resources from classpath.
+     */
+    default Route addClasspathResourceRoute(String urlPath, String resourceBasePath) {
+        return addResourceRoute(new ClasspathResourceHandler(urlPath, resourceBasePath));
+    }
+
+    /**
+     * It's a shortcut for {@link #addWebjarsResourceRoute(String)} with parameter <code>"/webjars"</code>.
+     */
+    default Route addWebjarsResourceRoute() {
+        return addWebjarsResourceRoute("/webjars");
+    }
+
+    /**
+     * Add a route that serves webjars (http://www.webjars.org/) resources.
+     */
+    default Route addWebjarsResourceRoute(String urlPath) {
+        return addResourceRoute(new WebjarsResourceHandler(urlPath));
+    }
+
+    default Route addResourceRoute(ResourceHandler resourceHandler) {
+        Route route = Route.GET(resourceHandler.getUriPattern(), resourceHandler);
+        addRoute(route);
+
+        return route;
+    }
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/route/Route.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Route.java
@@ -17,7 +17,6 @@ package ro.pippo.core.route;
 
 import ro.pippo.core.HttpConstants;
 import ro.pippo.core.PippoRuntimeException;
-import ro.pippo.core.util.StringUtils;
 
 /**
  * @author Decebal Suiu
@@ -153,13 +152,13 @@ public class Route {
         this.name = name;
     }
 
-    void setGroupUriPattern(String groupUriPattern) {
-        if (absoluteUriPattern != null) {
+    void setAbsoluteUriPattern(String absoluteUriPattern) {
+        if (this.absoluteUriPattern != null) {
             // when group1.addRoute(route); group2.addRoute(route);
             throw new PippoRuntimeException("This route is already in a group");
         }
 
-        absoluteUriPattern = StringUtils.concatUriPattern(groupUriPattern, this.uriPattern);
+        this.absoluteUriPattern = absoluteUriPattern;
     }
 
     @Override
@@ -173,14 +172,8 @@ public class Route {
 
         Route route = (Route) o;
 
-        if (!requestMethod.equals(route.requestMethod)) {
-            return false;
-        }
-        if (!getUriPattern().equals(route.getUriPattern())) {
-            return false;
-        }
+        return requestMethod.equals(route.requestMethod) && getUriPattern().equals(route.getUriPattern());
 
-        return true;
     }
 
     @Override

--- a/pippo-core/src/main/java/ro/pippo/core/route/RouteGroup.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/RouteGroup.java
@@ -15,9 +15,6 @@
  */
 package ro.pippo.core.route;
 
-import ro.pippo.core.PippoRuntimeException;
-import ro.pippo.core.util.StringUtils;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,12 +25,13 @@ import java.util.List;
  * Also you can add (route) filters for all routes of the group.
  *
  * @author ScienJus
+ * @author Decebal Suiu
  */
-public class RouteGroup {
+public class RouteGroup implements Routing {
 
     private String uriPattern;
     private List<Route> routes;
-//    private RouteGroup parent;
+    private RouteGroup parent;
     private List<RouteGroup> children;
 
     public RouteGroup(String uriPattern) {
@@ -41,14 +39,13 @@ public class RouteGroup {
     }
 
     public RouteGroup(RouteGroup parent, String uriPattern) {
+        this.uriPattern = uriPattern;
+        this.parent = parent;
+
         if (parent != null) {
-            this.uriPattern = StringUtils.concatUriPattern(parent.getUriPattern(), uriPattern);
-            parent.getChildren().add(this);
-        } else {
-            this.uriPattern = uriPattern;
+            parent.children.add(this);
         }
 
-//        this.parent = parent;
         this.routes = new ArrayList<>();
         this.children = new ArrayList<>();
     }
@@ -57,11 +54,9 @@ public class RouteGroup {
         return this.uriPattern;
     }
 
-    /*
     public RouteGroup getParent() {
         return parent;
     }
-    */
 
     public List<RouteGroup> getChildren() {
         return children;
@@ -71,90 +66,15 @@ public class RouteGroup {
         return routes;
     }
 
-    public Route GET(String uriPattern, RouteHandler routeHandler) {
-        if (routeHandler instanceof ResourceHandler) {
-            throw new PippoRuntimeException("Please use 'addResourceRoute()'");
-        }
-
-        Route route = Route.GET(uriPattern, routeHandler);
-        addRoute(route);
-
-        return route;
-    }
-
-    public Route GET(RouteHandler routeHandler) {
-        return GET("", routeHandler);
-    }
-
-    public Route POST(String uriPattern, RouteHandler routeHandler) {
-        Route route = Route.POST(uriPattern, routeHandler);
-        addRoute(route);
-
-        return route;
-    }
-
-    public Route POST(RouteHandler routeHandler) {
-        return POST("", routeHandler);
-    }
-
-    public Route DELETE(String uriPattern, RouteHandler routeHandler) {
-        Route route = Route.DELETE(uriPattern, routeHandler);
-        addRoute(route);
-
-        return route;
-    }
-
-    public Route DELETE(RouteHandler routeHandler) {
-        return DELETE("", routeHandler);
-    }
-
-    public Route HEAD(String uriPattern, RouteHandler routeHandler) {
-        Route route = Route.HEAD(uriPattern, routeHandler);
-        addRoute(route);
-
-        return route;
-    }
-
-    public Route HEAD(RouteHandler routeHandler) {
-        return HEAD("", routeHandler);
-    }
-
-    public Route PUT(String uriPattern, RouteHandler routeHandler) {
-        Route route = Route.PUT(uriPattern, routeHandler);
-        addRoute(route);
-
-        return route;
-    }
-
-    public Route PUT(RouteHandler routeHandler) {
-        return PUT("", routeHandler);
-    }
-
-    public Route PATCH(String uriPattern, RouteHandler routeHandler) {
-        Route route = Route.PATCH(uriPattern, routeHandler);
-        addRoute(route);
-
-        return route;
-    }
-
-    public Route PATCH(RouteHandler routeHandler) {
-        return PATCH("", routeHandler);
-    }
-
-    public Route ALL(String uriPattern, RouteHandler routeHandler) {
-        Route route = Route.ALL(uriPattern, routeHandler);
-        addRoute(route);
-
-        return route;
-    }
-
-    public Route ALL(RouteHandler routeHandler) {
-        return ALL("", routeHandler);
-    }
-
+    @Override
     public void addRoute(Route route) {
-        route.setGroupUriPattern(this.uriPattern);
         routes.add(route);
+    }
+
+    @Override
+    public void addRouteGroup(RouteGroup routeGroup) {
+        routeGroup.parent = this;
+        children.add(routeGroup);
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/route/Routing.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Routing.java
@@ -17,8 +17,6 @@ package ro.pippo.core.route;
 
 import ro.pippo.core.PippoRuntimeException;
 
-import java.io.File;
-
 /**
  * @author Decebal Suiu
  */
@@ -76,63 +74,6 @@ public interface Routing {
 
     default Route ALL(String uriPattern, RouteHandler routeHandler) {
         Route route = Route.ALL(uriPattern, routeHandler);
-        addRoute(route);
-
-        return route;
-    }
-
-    /**
-     * It's a shortcut for {@link #addPublicResourceRoute(String)} with parameter <code>"/public"</code>.
-     */
-    default Route addPublicResourceRoute() {
-        return addPublicResourceRoute("/public");
-    }
-
-    /**
-     * Add a route that serves resources from the "public" directory within your classpath.
-     */
-    default Route addPublicResourceRoute(String urlPath) {
-        return addResourceRoute(new PublicResourceHandler(urlPath));
-    }
-
-    /**
-     * Add a route that serves resources from a directory(file system).
-     */
-    default Route addFileResourceRoute(String urlPath, File directory) {
-        return addResourceRoute(new FileResourceHandler(urlPath, directory));
-    }
-
-    default Route addFileResourceRoute(String urlPath, String directory) {
-        return addResourceRoute(new FileResourceHandler(urlPath, directory));
-    }
-
-    default Route addClasspathResourceRoute(String urlPath, Class<?> resourceClass) {
-        return addResourceRoute(new ClasspathResourceHandler(urlPath, resourceClass.getName().replace(".", "/")));
-    }
-
-    /**
-     * Add a route that serves resources from classpath.
-     */
-    default Route addClasspathResourceRoute(String urlPath, String resourceBasePath) {
-        return addResourceRoute(new ClasspathResourceHandler(urlPath, resourceBasePath));
-    }
-
-    /**
-     * It's a shortcut for {@link #addWebjarsResourceRoute(String)} with parameter <code>"/webjars"</code>.
-     */
-    default Route addWebjarsResourceRoute() {
-        return addWebjarsResourceRoute("/webjars");
-    }
-
-    /**
-     * Add a route that serves webjars (http://www.webjars.org/) resources.
-     */
-    default Route addWebjarsResourceRoute(String urlPath) {
-        return addResourceRoute(new WebjarsResourceHandler(urlPath));
-    }
-
-    default Route addResourceRoute(ResourceHandler resourceHandler) {
-        Route route = Route.GET(resourceHandler.getUriPattern(), resourceHandler);
         addRoute(route);
 
         return route;

--- a/pippo-core/src/main/java/ro/pippo/core/util/StringUtils.java
+++ b/pippo-core/src/main/java/ro/pippo/core/util/StringUtils.java
@@ -197,6 +197,7 @@ public class StringUtils {
      */
     public static String format(String str, Object... args) {
         str = str.replaceAll("\\{\\}", "%s");
+
         return String.format(str, args);
     }
 
@@ -211,6 +212,7 @@ public class StringUtils {
         if (index > -1) {
             return value.substring(index + 1);
         }
+
         return "";
     }
 
@@ -226,12 +228,8 @@ public class StringUtils {
         if (index > -1) {
             return input.substring(0, index);
         }
-        return input;
-    }
 
-    public static String concatUriPattern(String prefix, String uriPattern) {
-        uriPattern = addStart(addStart(uriPattern, "/"), prefix);
-        return "/".equals(uriPattern) ? uriPattern : StringUtils.removeEnd(uriPattern, "/");
+        return input;
     }
 
 }

--- a/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/DefaultRouterTest.java
@@ -647,17 +647,6 @@ public class DefaultRouterTest {
     }
 
     @Test
-    public void testAddRouteWithGroup() {
-        RouteGroup group = new RouteGroup("/users");
-        Route route = group.GET("{id}", emptyRouteHandler);
-
-        router.addRoute(route);
-
-        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/users/1");
-        assertEquals(1, matches.size());
-    }
-
-    @Test
     public void testGroupAddRoute() {
         RouteGroup group = new RouteGroup("/users");
         Route route = Route.GET("{id}", emptyRouteHandler);
@@ -673,12 +662,55 @@ public class DefaultRouterTest {
     public void testNestGroup() {
         RouteGroup group = new RouteGroup("/users");
         RouteGroup child = new RouteGroup(group, "{id}");
-        Route route = Route.POST("like", emptyRouteHandler);
-        child.addRoute(route);
+        child.POST("like", emptyRouteHandler);
+        child.addRoute(Route.GET("help", emptyRouteHandler));
 
         router.addRouteGroup(group);
 
         List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.POST, "/users/1/like");
+        assertEquals(1, matches.size());
+
+        matches = router.findRoutes(HttpConstants.Method.GET, "/users/2/help");
+        assertEquals(1, matches.size());
+    }
+
+    @Test
+    public void testNestGroupWithCRUD() {
+        RouteGroup admin = new RouteGroup("/admin");
+        admin.GET("login", emptyRouteHandler);
+        admin.GET("logout", emptyRouteHandler);
+
+//        RouteGroup users = new RouteGroup(admin, "users");
+        RouteGroup users = new RouteGroup("users");
+        users.GET("{id}", emptyRouteHandler); // retrieves (all or a specific user)
+        users.PUT("{id}", emptyRouteHandler); // update a specific user
+        users.POST("", emptyRouteHandler); // create a new user
+        users.DELETE("/{id}", emptyRouteHandler); // delete a specific user
+        admin.addRouteGroup(users);
+
+        router.addRouteGroup(admin);
+
+        List<RouteMatch> matches = router.findRoutes(HttpConstants.Method.GET, "/admin/login");
+        assertEquals(1, matches.size());
+
+        matches = router.findRoutes(HttpConstants.Method.GET, "/admin/logout");
+        assertEquals(1, matches.size());
+
+        /*
+        matches = router.findRoutes(HttpConstants.Method.GET, "/admin/users");
+        assertEquals(1, matches.size());
+        */
+
+        matches = router.findRoutes(HttpConstants.Method.GET, "/admin/users/1");
+        assertEquals(1, matches.size());
+
+        matches = router.findRoutes(HttpConstants.Method.PUT, "/admin/users/2");
+        assertEquals(1, matches.size());
+
+        matches = router.findRoutes(HttpConstants.Method.POST, "/admin/users");
+        assertEquals(1, matches.size());
+
+        matches = router.findRoutes(HttpConstants.Method.DELETE, "/admin/users/3");
         assertEquals(1, matches.size());
     }
 
@@ -713,7 +745,7 @@ public class DefaultRouterTest {
         public UserGroup() {
             super("/users");
 
-            GET(emptyRouteHandler);
+            GET("", emptyRouteHandler);
         }
 
     }


### PR DESCRIPTION
I propose you an improvement of the `RouteGroup` concept. The change is small but the impact is great.
The idea is that I can create completely decoupled routes group and to create nice modular application.
A new method `addRouteGroup` was added in the `RouteGroup` class to allow us to add anytime a route group to another group. 

Before:
```java
class DemoApplication extends Application {

    @Override
    protected void onInit() {
        addRouteGroup(new AdminRoutes(this));
    }

}

class AdminRoutes extends RouteGroup {

    public AdminRoutes(Application appplication) {
        super("/admin");

        // BEFORE FILTERS
        addBeforeFilters();

        // ROUTES
        addRoutes();

        // GROUPS
        application.addRouteGroup(new UserRoutes(this));
        application.addRouteGroup(new CustomerRoutes(this));
    }

}
```

After:
```java
class DemoApplication extends Application {

    @Override
    protected void onInit() {
        addRouteGroup(new AdminRoutes());
    }

}

class AdminRoutes extends RouteGroup {

    public AdminRoutes() {
        super("/admin");

        // BEFORE FILTERS
        addBeforeFilters();

        // ROUTES
        addRoutes();

        // GROUPS
        addRouteGroup(new UserRoutes());
        addRouteGroup(new CustomerRoutes());
    }

}
```

So, now each `RouteGroup` is total separated, without a dependencies to parent (I don't need to know when I create a `RouteGroup` where the group will be mount). For example I can have a modular web application (built with _PF4J_ or other plugin framework) where each plugin comes with own independent routes (user management -> __UserRoutes__, customer management -> __CustomerRoutes__, ...). At runtime I can add these groups (discovered automatically by _PluginManager_ via _getExtensions(AppRoutes.class)_ method for example).   

The `RouteGroup` is a concept very import when you are forced to deal with a considerable number of routes in your application.   

The PR comes with some unit tests and I don't think that break the backward compatibility with the actual released version.