### PR TITLE
Inject Application instance in ServletContext

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/WebServer.java
+++ b/pippo-core/src/main/java/ro/pippo/core/WebServer.java
@@ -22,6 +22,55 @@ import javax.servlet.ServletContextListener;
  */
 public interface WebServer<T extends WebServerSettings> {
 
+    /**
+     * Attribute name used to retrieve the application instance from a {@link javax.servlet.ServletContext}.
+     * See {@link WebServerInitializer} and {@link ServletContextListener}.
+     *
+     * <pre>
+     * {@code
+     * MyApplication application = (MyApplication) servletContext.getAttribute(PIPPO_APPLICATION);
+     * }
+     * </pre>
+     *
+     * A possible scenario: I want to add support for Jersey in my application.
+     * <pre>
+     * {@code
+     *
+     * public class MyApplication extends Application {
+     *
+     *     public ResourceConfig getResourceConfig() {
+     *         return new ResourceConfig(MyResource.class);
+     *     }
+     *
+     *     // other possible methods
+     *
+     * }
+     *
+     * @MetaInfServices
+     * public class JerseyInitializer implements WebServerInitializer {
+     *
+     *     @Override
+     *     public void init(ServletContext servletContext) {
+     *         // get the resourceConfig via application
+     *         MyApplication application = (MyApplication) servletContext.getAttribute(PIPPO_APPLICATION);
+     *         ResourceConfig resourceConfig = application.getResourceConfig();
+     *
+     *         // add jersey filter
+     *         ServletRegistration.Dynamic jerseyServlet = servletContext.addServlet("jersey", new ServletContainer(resourceConfig));
+     *         jerseyServlet.setLoadOnStartup(1);
+     *         jerseyServlet.addMapping("/api/*");
+     *     }
+     *
+     *     @Override
+     *     public void destroy(ServletContext servletContext) {
+     *         // do nothing for now
+     *     }
+     *
+     * }
+     * </pre>
+     */
+    public static final String PIPPO_APPLICATION = "PIPPO_APPLICATION";
+
     T getSettings();
 
     PippoFilter getPippoFilter();

--- a/pippo-core/src/main/java/ro/pippo/core/WebServerInitializer.java
+++ b/pippo-core/src/main/java/ro/pippo/core/WebServerInitializer.java
@@ -20,6 +20,8 @@ import javax.servlet.ServletContext;
 /**
  * Interface to be implemented in Servlet 3.0+ environments in order to configure the
  * {@link ServletContext} programmatically.
+ * This interface is used by {@link PippoServletContextListener} so DON'T forget to annotate the
+ * implementations with {@code @MetaInfServices}.
  *
  * @author Decebal Suiu
  */

--- a/pippo-server-parent/pippo-jetty/src/main/java/ro/pippo/jetty/JettyServer.java
+++ b/pippo-server-parent/pippo-jetty/src/main/java/ro/pippo/jetty/JettyServer.java
@@ -165,6 +165,9 @@ public class JettyServer extends AbstractWebServer<JettySettings> {
         ServletContextHandler handler = new PippoHandler(ServletContextHandler.SESSIONS, multipartConfig);
         handler.setContextPath(getSettings().getContextPath());
 
+        // inject application as context attribute
+        handler.setAttribute(PIPPO_APPLICATION, pippoFilter.getApplication());
+
         // add pippo filter
         addPippoFilter(handler);
 

--- a/pippo-server-parent/pippo-tomcat/src/main/java/ro/pippo/tomcat/TomcatServer.java
+++ b/pippo-server-parent/pippo-tomcat/src/main/java/ro/pippo/tomcat/TomcatServer.java
@@ -116,6 +116,9 @@ public class TomcatServer extends AbstractWebServer<TomcatSettings> {
         context.addChild(wrapper);
         context.addServletMapping(pippoFilterPath, name);
 
+        // inject application as context attribute
+        context.getServletContext().setAttribute(PIPPO_APPLICATION, application);
+
         // add initializers
         context.addApplicationListener(PippoServletContextListener.class.getName());
 

--- a/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/UndertowServer.java
+++ b/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/UndertowServer.java
@@ -170,6 +170,9 @@ public class UndertowServer extends AbstractWebServer<UndertowSettings> {
         info.setContextPath(getSettings().getContextPath());
         info.setIgnoreFlush(true);
 
+        // inject application as context attribute
+        info.addServletContextAttribute(PIPPO_APPLICATION, pippoFilter.getApplication());
+
         // add pippo filter
         addPippoFilter(info);
 


### PR DESCRIPTION
In last time I tried to improve the interoperability between `Application` and `WebServer`.
For now we can add `Filter`, `Servlet` and `Listener` in a generic/uniform mode for all builtin `WebServer` types via `WebServerInitializer` and `WebServer.addListtener(ServletContextListener listener)`.
Practically we can customize in a easy mode many aspects of the `WebServer`. Using `Pippo.setServer(WebServer server)` we can customize any aspect of the embedded server.
With the current PR I propose you a simple but powerful solution to improve the interoperability between `Application` and other services (for example __Jersey__, __Guice__ via GuiceServletContextListener and others).
With this PR you have access to the `Application` instance from `ServletConetxt`.

Below, I will show you a practical case, how I can integrate Jersey in Pippo with with very few lines of code.

```java

import javax.ws.rs.GET;
import javax.ws.rs.Path;

@Path("/")
public class MyResource {

    @GET
    @Path("/hello")
    public String getMessage() {
        return "Hello World";
    }

}

import org.glassfish.jersey.server.ResourceConfig;

public class MyApplication extends Application {

    public ResourceConfig getResourceConfig() {
        return new ResourceConfig(MyResource.class);
     }
     
    // other possible methods

}

import ro.pippo.core.WebServer;

@MetaInfServices
public class JerseyInitializer implements WebServerInitializer {

    @Override
    public void init(ServletContext servletContext) {
        // get the resourceConfig via application
        MyApplication application = (MyApplication) servletContext.getAttribute(PIPPO_APPLICATION);
        ResourceConfig resourceConfig = application.getResourceConfig();

        // add jersey servlet and mapping this servlet on "/api/*"
        ServletRegistration.Dynamic jerseyServlet = servletContext.addServlet("jersey", new ServletContainer(resourceConfig));
        jerseyServlet.setLoadOnStartup(1);
        jerseyServlet.addMapping("/api/*");
    }

    @Override
    public void destroy(ServletContext servletContext) {
        // do nothing for now
    }

}

public class JerseyDemo {

    public static void main(String[] args) {
        Pippo pippo = new Pippo(new MyApplication());

        // set pippo filter path
        pippo.getServer().setPippoFilterPath("/app/*");

        pippo.start();
    }

}
``` 

In above example you can see that `JerseyInitializer` can be extracted easily in a `pippo-jersey` module (probably with an abstract method `createResourceConfig():ResourecConfig` or a simple convention `Application.getLocal("JERSEY_RESOURCE_CONFIG"):ResourceConfig`). 

I think this is the beginning of a beautiful friendship between `WebServer` (container and components) and Pippo :smile: 