### PR TITLE
Make Pippo class a little bit more expressive

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/Pippo.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Pippo.java
@@ -123,6 +123,16 @@ public class Pippo implements ResourceRouting {
         return this;
     }
 
+    /**
+     * Start the web server on this port.
+     *
+     * @param port
+     */
+    public void start(int port) {
+        getServer().setPort(port);
+        start();
+    }
+
     public void start() {
         if (running) {
             log.warn("Server is already started ");
@@ -155,6 +165,12 @@ public class Pippo implements ResourceRouting {
     @Override
     public void addRouteGroup(RouteGroup routeGroup) {
         getApplication().addRouteGroup(routeGroup);
+    }
+
+    public Pippo setFilterPath(String filterPath) {
+        getServer().setPippoFilterPath(filterPath);
+
+        return this;
     }
 
     /**

--- a/pippo-core/src/main/java/ro/pippo/core/WebServer.java
+++ b/pippo-core/src/main/java/ro/pippo/core/WebServer.java
@@ -103,4 +103,14 @@ public interface WebServer<T extends WebServerSettings> {
      */
     WebServer addListener(Class<? extends ServletContextListener> listener);
 
+    default int getPort() {
+        return getSettings().getPort();
+    }
+
+    default WebServer<T> setPort(int port) {
+        getSettings().port(port);
+
+        return this;
+    }
+
 }


### PR DESCRIPTION
A minor improvement that brings some fluency in Pippo launcher.

The old version:
```java
Pippo pippo = new Pippo();

// set port and filter path
WebServer server = pippo.getServer();
server.getSettings().port(8081);
server.setPippoFilterPath("/pippo/*");

pippo.start();
```

The new version:
```java
new Pippo()
    .setFilterPath("/pippo/*")
    .start(8081);
```

or
```java
new Pippo()
    .setPort(8081)
    .setFilterPath("/pippo/*")
    .start();
```
