### PR TITLE
Use gzip compression where it's possible; see #331

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/Application.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Application.java
@@ -17,6 +17,7 @@ package ro.pippo.core;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ro.pippo.core.gzip.GZipRequestResponseFactory;
 import ro.pippo.core.route.DefaultRouter;
 import ro.pippo.core.route.ResourceRouting;
 import ro.pippo.core.route.Route;
@@ -248,7 +249,8 @@ public class Application implements ResourceRouting {
      * @return
      */
     protected RequestResponseFactory createRequestResponseFactory() {
-        return new RequestResponseFactory(this);
+//        return new RequestResponseFactory(this);
+        return new GZipRequestResponseFactory(this);
     }
 
     /**

--- a/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoFilter.java
@@ -119,8 +119,9 @@ public class PippoFilter implements Filter {
 
         // create Request, Response objects
         RequestResponseFactory requestResponseFactory = application.getRequestResponseFactory();
-        Response response = requestResponseFactory.createResponse(httpServletResponse);
-        Request request = requestResponseFactory.createRequest(httpServletRequest, response);
+        RequestResponse requestResponse = requestResponseFactory.createRequestResponse(httpServletRequest, httpServletResponse);
+        Request request = requestResponse.getRequest();
+        Response response = requestResponse.getResponse();
 
         // create a URI to automatically decode the path
         URI uri = URI.create(httpServletRequest.getRequestURL().toString());

--- a/pippo-core/src/main/java/ro/pippo/core/PippoServlet.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoServlet.java
@@ -109,8 +109,9 @@ public class PippoServlet extends HttpServlet {
 
         // create Request, Response objects
         RequestResponseFactory requestResponseFactory = application.getRequestResponseFactory();
-        Response response = requestResponseFactory.createResponse(httpServletResponse);
-        Request request = requestResponseFactory.createRequest(httpServletRequest, response);
+        RequestResponse requestResponse = requestResponseFactory.createRequestResponse(httpServletRequest, httpServletResponse);
+        Request request = requestResponse.getRequest();
+        Response response = requestResponse.getResponse();
 
         // create a URI to automatically decode the path
         URI uri = URI.create(httpServletRequest.getRequestURL().toString());

--- a/pippo-core/src/main/java/ro/pippo/core/RequestResponse.java
+++ b/pippo-core/src/main/java/ro/pippo/core/RequestResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core;
+
+/**
+ * @author Decebal Suiu
+ */
+public class RequestResponse {
+
+    private final Request request;
+    private final Response response;
+
+    public RequestResponse(Request request, Response response) {
+        this.request = request;
+        this.response = response;
+    }
+
+    public Request getRequest() {
+        return request;
+    }
+
+    public Response getResponse() {
+        return response;
+    }
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/RequestResponseFactory.java
+++ b/pippo-core/src/main/java/ro/pippo/core/RequestResponseFactory.java
@@ -32,12 +32,11 @@ public class RequestResponseFactory {
         this.application = application;
     }
 
-    public Request createRequest(HttpServletRequest httpServletRequest, Response response) {
-        return new Request(httpServletRequest, application);
-    }
+    public RequestResponse createRequestResponse(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        Request request = new Request(httpServletRequest, application);
+        Response response = new Response(httpServletResponse, application);
 
-    public Response createResponse(HttpServletResponse httpServletResponse) {
-        return new Response(httpServletResponse, application);
+        return new RequestResponse(request, response);
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/gzip/GZipFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/gzip/GZipFilter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.gzip;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * {@code GZipFilter} will check the need of GZIP compression in request’s headers ‘Accept-Encoding: gzip’.
+ * Then, this filter uses two classes {@code GZipResponseWrapper} and {@code GZipResponseStream}
+ * to compress the data in response.
+ *
+ * @author Decebal Suiu
+ */
+public class GZipFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        // do nothing
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
+        throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        if (acceptsGZipEncoding(request)) {
+            GZipResponseWrapper wrappedResponse = new GZipResponseWrapper(response);
+            chain.doFilter(request, wrappedResponse);
+            wrappedResponse.finish();
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        // do nothing
+    }
+
+    protected boolean acceptsGZipEncoding(HttpServletRequest request) {
+        String acceptEncoding = request.getHeader("accept-encoding");
+
+        return acceptEncoding != null && acceptEncoding.contains("gzip");
+    }
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/gzip/GZipRequestResponseFactory.java
+++ b/pippo-core/src/main/java/ro/pippo/core/gzip/GZipRequestResponseFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.gzip;
+
+import ro.pippo.core.Application;
+import ro.pippo.core.Request;
+import ro.pippo.core.RequestResponse;
+import ro.pippo.core.RequestResponseFactory;
+import ro.pippo.core.Response;
+import ro.pippo.core.route.RoutePostDispatchListener;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Decebal Suiu
+ */
+public class GZipRequestResponseFactory extends RequestResponseFactory implements RoutePostDispatchListener {
+
+    public GZipRequestResponseFactory(Application application) {
+        super(application);
+
+        application.getRoutePostDispatchListeners().add(this);
+    }
+
+    @Override
+    public RequestResponse createRequestResponse(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        Request request = new Request(httpServletRequest, application);
+        Response response;
+
+        boolean acceptsGZipEncoding = acceptsGZipEncoding(httpServletRequest);
+        if (acceptsGZipEncoding) {
+            GZipResponseWrapper responseWrapper = new GZipResponseWrapper(httpServletResponse);
+            response = new Response(responseWrapper, application);
+        } else {
+            response = new Response(httpServletResponse, application);
+        }
+
+        return new RequestResponse(request, response);
+    }
+
+    @Override
+    public void onPostDispatch(Request request, Response response) {
+        HttpServletResponse httpServletResponse = response.getHttpServletResponse();
+        if (httpServletResponse instanceof GZipResponseWrapper) {
+            GZipResponseWrapper responseWrapper = (GZipResponseWrapper) httpServletResponse;
+            responseWrapper.finish();
+        }
+    }
+
+    protected boolean acceptsGZipEncoding(HttpServletRequest httpServletRequest) {
+        String acceptEncoding = httpServletRequest.getHeader("accept-encoding");
+
+        return acceptEncoding != null && acceptEncoding.contains("gzip");
+    }
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/gzip/GZipResponseStream.java
+++ b/pippo-core/src/main/java/ro/pippo/core/gzip/GZipResponseStream.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.gzip;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * @author Decebal Suiu
+ */
+public class GZipResponseStream extends ServletOutputStream {
+
+    private HttpServletResponse response;
+
+    private ByteArrayOutputStream byteArrayOutputStream;
+    private GZIPOutputStream gzipOutputStream;
+    private boolean closed;
+
+    public GZipResponseStream(HttpServletResponse response) throws IOException {
+        super();
+
+        this.response = response;
+
+        byteArrayOutputStream = new ByteArrayOutputStream();
+        gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            throw new IOException("This output stream has already been closed");
+        }
+
+        gzipOutputStream.finish();
+
+        byte[] bytes = byteArrayOutputStream.toByteArray();
+
+        response.addHeader("Content-Length", Integer.toString(bytes.length));
+        response.addHeader("Content-Encoding", "gzip");
+
+        ServletOutputStream outputStream = response.getOutputStream();
+        outputStream.write(bytes);
+        outputStream.flush();
+        outputStream.close();
+
+        closed = true;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        if (closed) {
+            throw new IOException("Cannot flush a closed output stream");
+        }
+
+        gzipOutputStream.flush();
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        if (closed) {
+            throw new IOException("Cannot write to a closed output stream");
+        }
+
+        gzipOutputStream.write((byte) b);
+    }
+
+    @Override
+    public void write(byte b[]) throws IOException {
+        write(b, 0, b.length);
+    }
+
+    @Override
+    public void write(byte b[], int off, int len) throws IOException {
+        if (closed) {
+            throw new IOException("Cannot write to a closed output stream");
+        }
+
+        gzipOutputStream.write(b, off, len);
+    }
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/gzip/GZipResponseWrapper.java
+++ b/pippo-core/src/main/java/ro/pippo/core/gzip/GZipResponseWrapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.gzip;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Decebal Suiu
+ */
+public class GZipResponseWrapper extends HttpServletResponseWrapper {
+
+    private HttpServletResponse response;
+    private ServletOutputStream stream;
+    private PrintWriter writer;
+
+    public GZipResponseWrapper(HttpServletResponse response) {
+        super(response);
+
+        this.response = response;
+    }
+
+    @Override
+    public void flushBuffer() throws IOException {
+        stream.flush();
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        if (writer != null) {
+            throw new IllegalStateException("getWriter() has already been called");
+        }
+
+        if (stream == null) {
+            stream = createOutputStream();
+        }
+
+        return stream;
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        if (writer != null) {
+            return writer;
+        }
+
+        if (stream != null) {
+            throw new IllegalStateException("getOutputStream() has already been called");
+        }
+
+        stream = createOutputStream();
+        writer = new PrintWriter(new OutputStreamWriter(stream, StandardCharsets.UTF_8));
+
+        return writer;
+    }
+
+    @Override
+    public void setContentLength(int length) {
+        // do nothing
+    }
+
+    void finish() {
+        try {
+            if (writer != null) {
+                writer.close();
+            } else {
+                if (stream != null) {
+                    stream.close();
+                }
+            }
+        } catch (IOException e) {
+            // ignore
+        }
+    }
+
+    private ServletOutputStream createOutputStream() throws IOException {
+        return new GZipResponseStream(response);
+    }
+
+}

--- a/pippo-session-parent/pippo-session-hazelcast/pom.xml
+++ b/pippo-session-parent/pippo-session-hazelcast/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hazelcast.version>3.6.3</hazelcast.version>
+        <hazelcast.version>3.7.4</hazelcast.version>
     </properties>
 
     <dependencies>

--- a/pippo-session-parent/pippo-session-hazelcast/src/test/java/ro/pippo/session/hazelcast/HazelcastSessionDataStorageTest.java
+++ b/pippo-session-parent/pippo-session-hazelcast/src/test/java/ro/pippo/session/hazelcast/HazelcastSessionDataStorageTest.java
@@ -21,7 +21,6 @@ import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import org.junit.Before;
 import org.junit.Test;
 import ro.pippo.session.SessionData;
 
@@ -33,16 +32,10 @@ public class HazelcastSessionDataStorageTest {
     private static final String SESSION_NAME = "session";
     private static final String KEY = "KEY";
     private static final String VALUE = "VALUE";
-    private HazelcastInstance hazelcastInstance;
-
-    @Before
-    public void setUp() {
-        hazelcastInstance = Hazelcast.newHazelcastInstance();
-    }
 
     @After
     public void tearDown() {
-        hazelcastInstance.shutdown();
+        Hazelcast.shutdownAll();
     }
 
     /**
@@ -51,7 +44,7 @@ public class HazelcastSessionDataStorageTest {
     @Test
     public void testCreate() {
         System.out.println("create");
-        HazelcastSessionDataStorage instance = new HazelcastSessionDataStorage(hazelcastInstance);
+        HazelcastSessionDataStorage instance = new HazelcastSessionDataStorage(Hazelcast.newHazelcastInstance());
         SessionData sessionData = instance.create();
         sessionData.put(KEY, VALUE);
         assertNotNull(sessionData);
@@ -65,9 +58,10 @@ public class HazelcastSessionDataStorageTest {
      */
     @Test
     public void testSave() {
+        HazelcastInstance hazelcastInstance1 = Hazelcast.newHazelcastInstance();
         HazelcastInstance hazelcastInstance2 = Hazelcast.newHazelcastInstance();
         System.out.println("save");
-        HazelcastSessionDataStorage instance = new HazelcastSessionDataStorage(hazelcastInstance);
+        HazelcastSessionDataStorage instance = new HazelcastSessionDataStorage(hazelcastInstance1);
         SessionData sessionData = instance.create();
         String sessionId = sessionData.getId();
         sessionData.put(KEY, VALUE);
@@ -76,7 +70,6 @@ public class HazelcastSessionDataStorageTest {
                 .<String, SessionData>getMap(SESSION_NAME)
                 .get(sessionId);
         assertEquals(sessionData, saved);
-        hazelcastInstance2.shutdown();
     }
 
     /**
@@ -85,7 +78,7 @@ public class HazelcastSessionDataStorageTest {
     @Test
     public void testGet() {
         System.out.println("get");
-        HazelcastSessionDataStorage instance = new HazelcastSessionDataStorage(hazelcastInstance);
+        HazelcastSessionDataStorage instance = new HazelcastSessionDataStorage(Hazelcast.newHazelcastInstance());
         SessionData sessionData = instance.create();
         String sessionId = sessionData.getId();
         sessionData.put(KEY, VALUE);
@@ -105,7 +98,7 @@ public class HazelcastSessionDataStorageTest {
     @Test
     public void testGetExpired() throws InterruptedException {
         System.out.println("get expired");
-        HazelcastSessionDataStorage instance = new HazelcastSessionDataStorage(hazelcastInstance);
+        HazelcastSessionDataStorage instance = new HazelcastSessionDataStorage(Hazelcast.newHazelcastInstance());
         SessionData sessionData = instance.create();
         String sessionId = sessionData.getId();
         sessionData.put(KEY, VALUE);
@@ -121,7 +114,7 @@ public class HazelcastSessionDataStorageTest {
     @Test
     public void testDelete() {
         System.out.println("delete");
-        HazelcastSessionDataStorage instance = new HazelcastSessionDataStorage(hazelcastInstance);
+        HazelcastSessionDataStorage instance = new HazelcastSessionDataStorage(Hazelcast.newHazelcastInstance());
         SessionData sessionData = instance.create();
         String sessionId = sessionData.getId();
         sessionData.put(KEY, VALUE);

--- a/pippo-session-parent/pippo-session-hazelcast/src/test/resources/hazelcast.xml
+++ b/pippo-session-parent/pippo-session-hazelcast/src/test/resources/hazelcast.xml
@@ -6,16 +6,8 @@
     <properties>
         <property name="hazelcast.logging.type">slf4j</property>
     </properties>
-    
-    <network>
-        <join>
-            <multicast enabled="true"/>
-        </join>
-    </network>
 
     <map name="session">
-        <backup-count>0</backup-count>
-        <async-backup-count>2</async-backup-count>
         <time-to-live-seconds>1</time-to-live-seconds>
         <max-idle-seconds>0</max-idle-seconds>
         <eviction-policy>LRU</eviction-policy>

--- a/pippo-session-parent/pippo-session/src/main/java/ro/pippo/session/SessionRequestResponseFactory.java
+++ b/pippo-session-parent/pippo-session/src/main/java/ro/pippo/session/SessionRequestResponseFactory.java
@@ -17,11 +17,12 @@ package ro.pippo.session;
 
 import ro.pippo.core.Application;
 import ro.pippo.core.Request;
+import ro.pippo.core.RequestResponse;
 import ro.pippo.core.RequestResponseFactory;
 import ro.pippo.core.Response;
-import ro.pippo.core.ResponseFinalizeListener;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author Decebal Suiu
@@ -37,18 +38,13 @@ public class SessionRequestResponseFactory extends RequestResponseFactory {
     }
 
     @Override
-    public Request createRequest(HttpServletRequest httpServletRequest, Response response) {
-        final SessionHttpServletRequest sessionHttpServletRequest = new SessionHttpServletRequest(httpServletRequest, sessionManager);
-        response.getFinalizeListeners().add(new ResponseFinalizeListener() {
+    public RequestResponse createRequestResponse(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        SessionHttpServletRequest sessionHttpServletRequest = new SessionHttpServletRequest(httpServletRequest, sessionManager);
+        Request request = new Request(sessionHttpServletRequest, application);
+        Response response = new Response(httpServletResponse, application);
+        response.getFinalizeListeners().add(r -> sessionHttpServletRequest.commitSession(httpServletResponse));
 
-            @Override
-            public void onFinalize(Response response) {
-                sessionHttpServletRequest.commitSession(response.getHttpServletResponse());
-            }
-
-        });
-
-        return super.createRequest(sessionHttpServletRequest, response);
+        return new RequestResponse(request, response);
     }
 
 }


### PR DESCRIPTION
See #31 for more details.

I made some tests and everything is OK. 
So, this compression is used out of the box (you as developer do nothing) if the client (the browser - I tested on Chrome) accept "gzip" as encoding.
I made a little refactoring, `RequestResponseFactory` contains only a method `createRequestResponse(HttpServletRequest, HttpServletResponse):RequestResponse`. Practically I merged  `createRequest` and `createResponse` methods in one method `createRequestResponse` because are multiple situation when I need to have access from response to request and vice versa. I hope that this modification doesn't affect you.

Of course any advice, question is welcome. 