### PR TITLE
Fixes #338

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java
+++ b/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java
@@ -239,7 +239,7 @@ public class ParameterValue implements Serializable {
     }
 
     public Set<String> toSet(Set<String> defaultValue) {
-        if (isNull()) {
+        if (isNull() || (values.length == 1 && StringUtils.isNullOrEmpty(values[0]))) {
             return defaultValue;
         }
 
@@ -278,7 +278,7 @@ public class ParameterValue implements Serializable {
     }
 
     public List<String> toList(List<String> defaultValue) {
-        if (isNull()) {
+        if (isNull() || (values.length == 1 && StringUtils.isNullOrEmpty(values[0]))) {
             return defaultValue;
         }
 

--- a/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 
@@ -196,6 +197,13 @@ public class ParameterValueTest {
     }
 
     @Test
+    public void testEmptySet() throws Exception {
+        assertEquals(Collections.emptySet(), new ParameterValue("").toSet());
+        assertEquals(Collections.emptySet(), new ParameterValue("  ").toSet());
+        assertEquals(Collections.emptySet(), new ParameterValue(" ").toSet(Integer.class));
+    }
+
+    @Test
     public void testStringHashSet() throws Exception {
         Set<String> mySet = new HashSet<>(Arrays.asList("A", "B", "C"));
         Set<String> targetSet = new ParameterValue("C", "B", "A").toSet(String.class);
@@ -230,6 +238,13 @@ public class ParameterValueTest {
     public void testEncodedTreeSet() throws Exception {
         TreeSet<Integer> mySet = new TreeSet<>(Arrays.asList(600, 200, 400, 200));
         assertEquals(mySet, new ParameterValue("[600, 400, 200]").toCollection(TreeSet.class, Integer.class, null));
+    }
+
+    @Test
+    public void testEmptyArrayList() throws Exception {
+        assertEquals(Collections.emptyList(), new ParameterValue("").toList());
+        assertEquals(Collections.emptyList(), new ParameterValue("  ").toList());
+        assertEquals(Collections.emptyList(), new ParameterValue(" ").toList(Integer.class));
     }
 
     @Test


### PR DESCRIPTION
Return empty list when `toList()` is called for parameter with empty string as its value