### PR TITLE
Move PippoFilter instantiation from Pippo class to the WebServer implementations (breaking change)

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/AbstractWebServer.java
+++ b/pippo-core/src/main/java/ro/pippo/core/AbstractWebServer.java
@@ -24,10 +24,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public abstract class AbstractWebServer<T extends WebServerSettings> implements WebServer<T> {
 
-    protected PippoFilter pippoFilter;
+    private PippoFilter pippoFilter;
     protected String pippoFilterPath;
 
-    protected PippoSettings pippoSettings;
+    private Application application;
     private T settings;
 
     protected List<Class<? extends EventListener>> listeners;
@@ -49,12 +49,25 @@ public abstract class AbstractWebServer<T extends WebServerSettings> implements 
 
     @Override
     public PippoFilter getPippoFilter() {
+        if (pippoFilter == null) {
+            setPippoFilter(createPippoFilter());
+        }
+
         return pippoFilter;
     }
 
+    /**
+     * Set the {@link PippoFilter} instance.
+     * This method call {@link PippoFilter#setApplication(Application)} to end.
+     *
+     * @param pippoFilter
+     * @return
+     */
     @Override
     public WebServer<T> setPippoFilter(PippoFilter pippoFilter) {
         this.pippoFilter = pippoFilter;
+
+        pippoFilter.setApplication(application);
 
         return this;
     }
@@ -74,8 +87,8 @@ public abstract class AbstractWebServer<T extends WebServerSettings> implements 
     }
 
     @Override
-    public WebServer<T> init(PippoSettings pippoSettings) {
-        this.pippoSettings = pippoSettings;
+    public WebServer<T> init(Application application) {
+        this.application = application;
 
         return this;
     }
@@ -85,6 +98,28 @@ public abstract class AbstractWebServer<T extends WebServerSettings> implements 
         listeners.add(listener);
 
         return this;
+    }
+
+    public Application getApplication() {
+        return application;
+    }
+
+    /**
+     * Override this method if you want to customize the {@link PippoFilter}.
+     * <p/>
+     * <pre>
+     * protected PippoFilter createPippoFilter() {
+     *     PippoFilter pippoFilter = super.createPippoFilter();
+     *     pippoFilter.setIgnorePaths(Collections.singleton("/favicon.ico"));
+     *
+     *     return pippoFilter;
+     * }
+     * </pre>
+     *
+     * @return
+     */
+    protected PippoFilter createPippoFilter() {
+        return new PippoFilter();
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/WebServer.java
+++ b/pippo-core/src/main/java/ro/pippo/core/WebServer.java
@@ -88,7 +88,7 @@ public interface WebServer<T extends WebServerSettings> {
      */
     WebServer<T> setPippoFilterPath(String pippoFilterPath);
 
-    WebServer<T> init(PippoSettings pippoSettings);
+    WebServer<T> init(Application application);
 
     void start();
 

--- a/pippo-server-parent/pippo-jetty/src/main/java/ro/pippo/jetty/JettyServer.java
+++ b/pippo-server-parent/pippo-jetty/src/main/java/ro/pippo/jetty/JettyServer.java
@@ -91,7 +91,7 @@ public class JettyServer extends AbstractWebServer<JettySettings> {
 
     @Override
     protected JettySettings createDefaultSettings() {
-        return new JettySettings(pippoSettings);
+        return new JettySettings(getApplication().getPippoSettings());
     }
 
     protected void internalStart() {
@@ -166,7 +166,7 @@ public class JettyServer extends AbstractWebServer<JettySettings> {
         handler.setContextPath(getSettings().getContextPath());
 
         // inject application as context attribute
-        handler.setAttribute(PIPPO_APPLICATION, pippoFilter.getApplication());
+        handler.setAttribute(PIPPO_APPLICATION, getApplication());
 
         // add pippo filter
         addPippoFilter(handler);
@@ -187,7 +187,7 @@ public class JettyServer extends AbstractWebServer<JettySettings> {
     }
 
     private MultipartConfigElement createMultipartConfigElement() {
-        Application application = pippoFilter.getApplication();
+        Application application = getApplication();
         String location = application.getUploadLocation();
         long maxFileSize = application.getMaximumUploadSize();
 
@@ -201,7 +201,7 @@ public class JettyServer extends AbstractWebServer<JettySettings> {
 
         EnumSet<DispatcherType> dispatches = EnumSet.of(DispatcherType.REQUEST, DispatcherType.ERROR);
 
-        FilterHolder pippoFilterHolder = new FilterHolder(pippoFilter);
+        FilterHolder pippoFilterHolder = new FilterHolder(getPippoFilter());
         handler.addFilter(pippoFilterHolder, pippoFilterPath, dispatches);
         log.debug("Using pippo filter for path '{}'", pippoFilterPath);
     }

--- a/pippo-server-parent/pippo-tjws/src/main/java/ro/pippo/tjws/TjwsServer.java
+++ b/pippo-server-parent/pippo-tjws/src/main/java/ro/pippo/tjws/TjwsServer.java
@@ -116,7 +116,7 @@ public class TjwsServer extends AbstractWebServer<WebServerSettings> {
 
     @Override
     protected WebServerSettings createDefaultSettings() {
-        return new WebServerSettings(pippoSettings);
+        return new WebServerSettings(getApplication().getPippoSettings());
     }
 
 }

--- a/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/UndertowServer.java
+++ b/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/UndertowServer.java
@@ -105,7 +105,7 @@ public class UndertowServer extends AbstractWebServer<UndertowSettings> {
 
     @Override
     protected UndertowSettings createDefaultSettings() {
-        return new UndertowSettings(pippoSettings);
+        return new UndertowSettings(getApplication().getPippoSettings());
     }
 
     protected Undertow createServer(HttpHandler contextHandler) {
@@ -171,7 +171,7 @@ public class UndertowServer extends AbstractWebServer<UndertowSettings> {
         info.setIgnoreFlush(true);
 
         // inject application as context attribute
-        info.addServletContextAttribute(PIPPO_APPLICATION, pippoFilter.getApplication());
+        info.addServletContextAttribute(PIPPO_APPLICATION, getApplication());
 
         // add pippo filter
         addPippoFilter(info);
@@ -196,7 +196,7 @@ public class UndertowServer extends AbstractWebServer<UndertowSettings> {
     }
 
     private MultipartConfigElement createMultipartConfigElement() {
-        Application application = pippoFilter.getApplication();
+        Application application = getApplication();
         String location = application.getUploadLocation();
         long maxFileSize = application.getMaximumUploadSize();
 
@@ -208,7 +208,7 @@ public class UndertowServer extends AbstractWebServer<UndertowSettings> {
             pippoFilterPath = "/*"; // default value
         }
 
-        info.addFilter(new FilterInfo("PippoFilter", PippoFilter.class, new ImmediateInstanceFactory<>(pippoFilter)));
+        info.addFilter(new FilterInfo("PippoFilter", PippoFilter.class, new ImmediateInstanceFactory<>(getPippoFilter())));
         info.addFilterUrlMapping("PippoFilter", pippoFilterPath, DispatcherType.REQUEST);
         log.debug("Using pippo filter for path '{}'", pippoFilterPath);
     }


### PR DESCRIPTION
This modification help me to move forward the branch with the WebSocket support (that will be available in next release).
I believe that this move is natural and it adds more clarity to API. It's the responsibility of `WebServer` to deals with `PippoFilter`.
The drawback is that this PR comes with a change in the API but, the change is in a zone that it's too visited. 