### PR TITLE
Support configuring the Jackson Object Mapper

### DIFF
--- a/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonBaseEngine.java
+++ b/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonBaseEngine.java
@@ -39,17 +39,13 @@ public abstract class JacksonBaseEngine implements ContentTypeEngine {
 
     @Override
     public void init(Application application) {
-        objectMapper = constructObjectMapper();
+        objectMapper = createObjectMapper();
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         objectMapper.setTimeZone(TimeZone.getDefault());
         objectMapper.registerModule(new AfterburnerModule());
     }
 
-    public ObjectMapper getObjectMapper() {
-        return objectMapper;
-    }
-
-    protected abstract ObjectMapper constructObjectMapper();
+    protected abstract ObjectMapper createObjectMapper();
 
     @Override
     public String toString(Object object) {

--- a/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonBaseEngine.java
+++ b/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonBaseEngine.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import ro.pippo.core.Application;
 import ro.pippo.core.ContentTypeEngine;
-import ro.pippo.core.HttpConstants;
 import ro.pippo.core.PippoRuntimeException;
 
 import java.io.IOException;
@@ -36,17 +35,21 @@ import java.util.TimeZone;
  */
 public abstract class JacksonBaseEngine implements ContentTypeEngine {
 
-    protected ObjectMapper objectMapper;
+    private ObjectMapper objectMapper;
 
     @Override
     public void init(Application application) {
-        objectMapper = getObjectMapper();
+        objectMapper = constructObjectMapper();
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         objectMapper.setTimeZone(TimeZone.getDefault());
         objectMapper.registerModule(new AfterburnerModule());
     }
 
-    protected abstract ObjectMapper getObjectMapper();
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+    protected abstract ObjectMapper constructObjectMapper();
 
     @Override
     public String toString(Object object) {

--- a/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonJsonEngine.java
+++ b/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonJsonEngine.java
@@ -29,7 +29,7 @@ import ro.pippo.core.HttpConstants;
 public class JacksonJsonEngine extends JacksonBaseEngine {
 
     @Override
-    protected ObjectMapper getObjectMapper() {
+    protected ObjectMapper constructObjectMapper() {
         return new ObjectMapper();
     }
 

--- a/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonJsonEngine.java
+++ b/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonJsonEngine.java
@@ -29,7 +29,7 @@ import ro.pippo.core.HttpConstants;
 public class JacksonJsonEngine extends JacksonBaseEngine {
 
     @Override
-    protected ObjectMapper constructObjectMapper() {
+    protected ObjectMapper createObjectMapper() {
         return new ObjectMapper();
     }
 

--- a/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonXmlEngine.java
+++ b/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonXmlEngine.java
@@ -31,7 +31,7 @@ import ro.pippo.core.HttpConstants;
 public class JacksonXmlEngine extends JacksonBaseEngine {
 
     @Override
-    protected ObjectMapper constructObjectMapper() {
+    protected ObjectMapper createObjectMapper() {
         // Check out: https://github.com/FasterXML/jackson-dataformat-xml
         JacksonXmlModule module = new JacksonXmlModule();
         // setDefaultUseWrapper produces more similar output to

--- a/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonXmlEngine.java
+++ b/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonXmlEngine.java
@@ -31,7 +31,7 @@ import ro.pippo.core.HttpConstants;
 public class JacksonXmlEngine extends JacksonBaseEngine {
 
     @Override
-    protected ObjectMapper getObjectMapper() {
+    protected ObjectMapper constructObjectMapper() {
         // Check out: https://github.com/FasterXML/jackson-dataformat-xml
         JacksonXmlModule module = new JacksonXmlModule();
         // setDefaultUseWrapper produces more similar output to

--- a/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonYamlEngine.java
+++ b/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonYamlEngine.java
@@ -30,7 +30,7 @@ import ro.pippo.core.HttpConstants;
 public class JacksonYamlEngine extends JacksonBaseEngine {
 
     @Override
-    protected ObjectMapper getObjectMapper() {
+    protected ObjectMapper constructObjectMapper() {
         return new YAMLMapper();
     }
 

--- a/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonYamlEngine.java
+++ b/pippo-content-type-parent/pippo-jackson/src/main/java/ro/pippo/jackson/JacksonYamlEngine.java
@@ -30,7 +30,7 @@ import ro.pippo.core.HttpConstants;
 public class JacksonYamlEngine extends JacksonBaseEngine {
 
     @Override
-    protected ObjectMapper constructObjectMapper() {
+    protected ObjectMapper createObjectMapper() {
         return new YAMLMapper();
     }
 


### PR DESCRIPTION
This change provides a getter for the Jackson Object Mapper so that Pippo applications can customize it as they need. E.g. I have this in my `onInit`:
```Java
ContentTypeEngine applicationJsonEngine = getContentTypeEngine(APPLICATION_JSON);
if (applicationJsonEngine instanceof JacksonJsonEngine) {
    JacksonJsonEngine jacksonJsonEngine = (JacksonJsonEngine) applicationJsonEngine;
    ObjectMapper objectMapper = jacksonJsonEngine.getObjectMapper();
    objectMapper.registerModule(new Jdk8Module());
    objectMapper.registerModule(new GuavaModule());
} else {
    throw new IllegalStateException(String.format(
            "Cannot launch without Jackson engine registered to handle %s content.", APPLICATION_JSON));
}
```