### PR TITLE
Add support to configure undertow

### DIFF
--- a/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/UndertowServer.java
+++ b/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/UndertowServer.java
@@ -147,6 +147,8 @@ public class UndertowServer extends AbstractWebServer<UndertowSettings> {
             }
         }
 
+        // add undertow options
+        getSettings().addUndertowOptions(builder);
         builder.setHandler(contextHandler);
 
         return builder.build();


### PR DESCRIPTION
- Pick undertow options from pippoSettings.
- All parameters would be in this format undertow.<type>.<parameter>
type has 3 values - server, socket, worker

Currently maintaining map in `UndetowSettings` which maintains mapping between parameter and its type.
If this approach is okay, I will add more parameters to map in `UndertowSettings` to the parameter list as extensive. 
Also, Could you suggest way to add any parameter without using map (currently map has to be maintained to know parameter type)
This fix is related to issue #359 