### PR TITLE
TemplateEngine customization and extension support 

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/AbstractTemplateEngine.java
+++ b/pippo-core/src/main/java/ro/pippo/core/AbstractTemplateEngine.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core;
+
+import ro.pippo.core.route.RouteContext;
+import ro.pippo.core.route.Router;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.io.Writer;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Convenience abstract implementation of {@link TemplateEngine}
+ *
+ * A configuration configuration target <code>CT</code> is a template engine specific component
+ * that needs to be setup for the engine to function correctly.
+ *
+ * To use the convenience methods in this class, implementations must override {@link #init(Application)}
+ * and call this class' implementation before performing any of their initialization.
+ *
+ * @param <CT> configuration target for custom initialization, implementations could use this
+ *
+ * @see TemplateEngine
+ *
+ * @author Ranganath Kini
+ */
+public abstract class AbstractTemplateEngine<CT> implements TemplateEngine {
+
+    private Languages languages;
+    private Messages messages;
+    private Router router;
+    private PippoSettings pippoSettings;
+
+    private String fileExtension;
+    private String templatePathPrefix;
+
+    /**
+     * Performs common initialization for template engines
+     *
+     * Implementations must override this method to do their own template engine specific initialization. To
+     * use the convenience of this class, implementations must invoke this class's implementation before
+     * performing their own initialization.
+     *
+     * @param application reference to the Pippo {@link Application} that can be used to retrieve settings
+     *                     and other settings for the initialization
+     */
+    @Override
+    public void init(Application application) {
+        languages = application.getLanguages();
+        messages = application.getMessages();
+        router = application.getRouter();
+        pippoSettings = application.getPippoSettings();
+
+        fileExtension = pippoSettings.getString(PippoConstants.SETTING_TEMPLATE_EXTENSION, getDefaultFileExtension());
+        templatePathPrefix = pippoSettings.getString(PippoConstants.SETTING_TEMPLATE_PATH_PREFIX, TemplateEngine.DEFAULT_PATH_PREFIX);
+    }
+
+    /**
+     * Performs additional initialization on the specified template engine specific configuration target
+     *
+     * This method serves as a hook for implementation to support additional fine-grained extension to initialize
+     * a template engine specific configuration object.
+     *
+     * Implementations can support this by invoking this method from {@link #init(Application)}.
+     * Supporting this is completely optional.
+     *
+     * The default implementation throws a {@link NotImplementedException}.
+     *
+     * @param application reference to the Pippo {@link Application} the can be used to access configuration details
+     * @param configurationTarget reference to the template engine specific configuration object that needs initialization
+     *
+     * @throws NotImplementedException
+     *          if no additional initialization is supported by the implementation
+     */
+    protected void init(Application application, CT configurationTarget) {
+        throw new NotImplementedException();
+    }
+
+    /**
+     * @see TemplateEngine#renderString(String, Map, Writer)
+     */
+    @Override
+    public abstract void renderString(String templateContent, Map<String, Object> model, Writer writer);
+
+    /**
+     * @see TemplateEngine#renderResource(String, Map, Writer)
+     */
+    @Override
+    public abstract void renderResource(String templateName, Map<String, Object> model, Writer writer);
+
+    /**
+     * Returns the default file extension for template resources.
+     *
+     * This will be used in case there is <code>template.extension</code> is not provided in
+     * application settings.
+     *
+     * @return String the default file extension for templates resources
+     */
+    protected abstract String getDefaultFileExtension();
+
+    /**
+     * @see TemplateEngine#setFileExtension(String)
+     */
+    @Override
+    public final void setFileExtension(String extension) { this.fileExtension = extension; }
+
+    /**
+     * Returns the configured file extension for template resources
+     *
+     * @return String the configured file extension for template resources
+     */
+    protected final String getFileExtension() { return fileExtension; }
+
+    /**
+     * @see Application#getMessages()
+     */
+    protected final Messages getMessages() { return this.messages; }
+
+    /**
+     * @see Application#getPippoSettings()
+     */
+    protected final PippoSettings getPippoSettings() { return pippoSettings; }
+
+    /**
+     * @see Languages#getLocaleOrDefault(String)
+     */
+    protected final Locale getLocaleOrDefault(String language) { return languages.getLocaleOrDefault(language); }
+
+    /**
+     * @see Languages#getLocaleOrDefault(RouteContext)
+     */
+    protected final Locale getLocaleOrDefault(RouteContext routeContext) {
+        return languages.getLocaleOrDefault(routeContext);
+    }
+
+    /**
+     * @see Languages#getLanguageOrDefault(String)
+     */
+    protected final String getLanguageOrDefault(String language) { return languages.getLanguageOrDefault(language); }
+
+    /**
+     * @see Languages#getLanguageOrDefault(RouteContext)
+     */
+    protected final String getLanguageOrDefault(RouteContext routeContext) {
+        return languages.getLanguageOrDefault(routeContext);
+    }
+
+    /**
+     * @see Application#getRouter()
+     */
+    protected final Router getRouter() { return router; }
+
+    /**
+     * Returns the template path prefix to be used to load template resources
+     *
+     * @return String the template path prefix for loading template resources
+     */
+    protected final String getTemplatePathPrefix() { return templatePathPrefix; }
+}

--- a/pippo-core/src/main/java/ro/pippo/core/AbstractTemplateEngine.java
+++ b/pippo-core/src/main/java/ro/pippo/core/AbstractTemplateEngine.java
@@ -85,6 +85,11 @@ public abstract class AbstractTemplateEngine implements TemplateEngine {
     protected final String getFileExtension() { return fileExtension; }
 
     /**
+     * @see Application#getLanguages()
+     */
+    protected final Languages getLanguages() { return languages; }
+
+    /**
      * @see Application#getMessages()
      */
     protected final Messages getMessages() { return this.messages; }

--- a/pippo-core/src/main/java/ro/pippo/core/AbstractTemplateEngine.java
+++ b/pippo-core/src/main/java/ro/pippo/core/AbstractTemplateEngine.java
@@ -17,28 +17,20 @@ package ro.pippo.core;
 
 import ro.pippo.core.route.RouteContext;
 import ro.pippo.core.route.Router;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
-import java.io.Writer;
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * Convenience abstract implementation of {@link TemplateEngine}
  *
- * A configuration configuration target <code>CT</code> is a template engine specific component
- * that needs to be setup for the engine to function correctly.
- *
  * To use the convenience methods in this class, implementations must override {@link #init(Application)}
  * and call this class' implementation before performing any of their initialization.
- *
- * @param <CT> configuration target for custom initialization, implementations could use this
  *
  * @see TemplateEngine
  *
  * @author Ranganath Kini
  */
-public abstract class AbstractTemplateEngine<CT> implements TemplateEngine {
+public abstract class AbstractTemplateEngine implements TemplateEngine {
 
     private Languages languages;
     private Messages messages;
@@ -68,39 +60,6 @@ public abstract class AbstractTemplateEngine<CT> implements TemplateEngine {
         fileExtension = pippoSettings.getString(PippoConstants.SETTING_TEMPLATE_EXTENSION, getDefaultFileExtension());
         templatePathPrefix = pippoSettings.getString(PippoConstants.SETTING_TEMPLATE_PATH_PREFIX, TemplateEngine.DEFAULT_PATH_PREFIX);
     }
-
-    /**
-     * Performs additional initialization on the specified template engine specific configuration target
-     *
-     * This method serves as a hook for implementation to support additional fine-grained extension to initialize
-     * a template engine specific configuration object.
-     *
-     * Implementations can support this by invoking this method from {@link #init(Application)}.
-     * Supporting this is completely optional.
-     *
-     * The default implementation throws a {@link NotImplementedException}.
-     *
-     * @param application reference to the Pippo {@link Application} the can be used to access configuration details
-     * @param configurationTarget reference to the template engine specific configuration object that needs initialization
-     *
-     * @throws NotImplementedException
-     *          if no additional initialization is supported by the implementation
-     */
-    protected void init(Application application, CT configurationTarget) {
-        throw new NotImplementedException();
-    }
-
-    /**
-     * @see TemplateEngine#renderString(String, Map, Writer)
-     */
-    @Override
-    public abstract void renderString(String templateContent, Map<String, Object> model, Writer writer);
-
-    /**
-     * @see TemplateEngine#renderResource(String, Map, Writer)
-     */
-    @Override
-    public abstract void renderResource(String templateName, Map<String, Object> model, Writer writer);
 
     /**
      * Returns the default file extension for template resources.

--- a/pippo-core/src/main/java/ro/pippo/core/PippoConstants.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoConstants.java
@@ -77,6 +77,8 @@ public final class PippoConstants {
 
     public static final String REQUEST_PARAMETER_LOCALE = "locale";
 
+    public static final String SETTING_TEMPLATE_EXTENSION = "template.extension";
+
     // OTHERS
 
     public static final String UTF8 = StandardCharsets.UTF_8.toString();

--- a/pippo-core/src/test/java/ro/pippo/core/AbstractTemplateEngineTests.java
+++ b/pippo-core/src/test/java/ro/pippo/core/AbstractTemplateEngineTests.java
@@ -216,7 +216,7 @@ public class AbstractTemplateEngineTests {
         reset(mockLanguages);
     }
 
-    private static class TestTemplateEngine extends AbstractTemplateEngine<String> {
+    private static class TestTemplateEngine extends AbstractTemplateEngine {
 
         @Override
         public void init(Application application) {

--- a/pippo-core/src/test/java/ro/pippo/core/AbstractTemplateEngineTests.java
+++ b/pippo-core/src/test/java/ro/pippo/core/AbstractTemplateEngineTests.java
@@ -24,8 +24,6 @@ public class AbstractTemplateEngineTests {
 
     private static final String EXPECTED_LANGUAGE = "en_US";
     private static final Locale EXPECTED_LOCALE = Locale.forLanguageTag(EXPECTED_LANGUAGE);
-    private static final String EXPECTED_CONTEXT_PATH = "/";
-    private static final String EXPECTED_APPLICATION_PATH = "/";
     private static final String EXPECTED_DEFAULT_FILE_EXTENSION = "test";
     private static final String EXPECTED_FILE_EXTENSION = "foo";
     private static final String EXPECTED_TEMPLATE_PATH_PREFIX = "/testTemplates";

--- a/pippo-core/src/test/java/ro/pippo/core/AbstractTemplateEngineTests.java
+++ b/pippo-core/src/test/java/ro/pippo/core/AbstractTemplateEngineTests.java
@@ -1,0 +1,241 @@
+package ro.pippo.core;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+import ro.pippo.core.route.RouteContext;
+import ro.pippo.core.route.Router;
+
+import java.io.Writer;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractTemplateEngineTests {
+
+    private static final String EXPECTED_LANGUAGE = "en_US";
+    private static final Locale EXPECTED_LOCALE = Locale.forLanguageTag(EXPECTED_LANGUAGE);
+    private static final String EXPECTED_CONTEXT_PATH = "/";
+    private static final String EXPECTED_APPLICATION_PATH = "/";
+    private static final String EXPECTED_DEFAULT_FILE_EXTENSION = "test";
+    private static final String EXPECTED_FILE_EXTENSION = "foo";
+    private static final String EXPECTED_TEMPLATE_PATH_PREFIX = "/testTemplates";
+
+    @Mock
+    private Application mockApplication;
+
+    @Mock
+    private PippoSettings mockPippoSettings;
+
+    @Mock
+    private Languages mockLanguages;
+
+    @Mock
+    private Messages mockMessages;
+
+    @Mock
+    private Router mockRouter;
+
+    private TestTemplateEngine templateEngine;
+
+    @Before
+    public void setupApplication() {
+        MockitoAnnotations.initMocks(this);
+        templateEngine = new TestTemplateEngine();
+
+        when(mockApplication.getPippoSettings()).thenReturn(mockPippoSettings);
+        when(mockApplication.getLanguages()).thenReturn(mockLanguages);
+        when(mockApplication.getMessages()).thenReturn(mockMessages);
+        when(mockApplication.getRouter()).thenReturn(mockRouter);
+    }
+
+    @Test
+    public void shouldGetLocaleOrDefaultForSpecifiedLanguageFromApplicationLanguages() {
+        when(mockLanguages.getLocaleOrDefault(EXPECTED_LANGUAGE)).thenReturn(EXPECTED_LOCALE);
+
+        templateEngine.init(mockApplication);
+
+        Locale locale = templateEngine.getLocaleOrDefault(EXPECTED_LANGUAGE);
+
+        assertThat(locale, is(EXPECTED_LOCALE));
+
+        verify(mockLanguages, times(1)).getLocaleOrDefault(EXPECTED_LANGUAGE);
+        verify(mockApplication, times(1)).getLanguages();
+    }
+
+    @Test
+    public void shouldGetLocaleOrDefaultForSpecifiedRouteContextFromApplicationLanguages() {
+        RouteContext routeContext = mock(RouteContext.class);
+
+        when(mockLanguages.getLocaleOrDefault(any(RouteContext.class))).thenReturn(EXPECTED_LOCALE);
+
+        templateEngine.init(mockApplication);
+
+        Locale locale = templateEngine.getLocaleOrDefault(routeContext);
+
+        assertThat(locale, is(EXPECTED_LOCALE));
+
+        verify(mockLanguages, times(1)).getLocaleOrDefault(eq(routeContext));
+        verify(mockApplication, times(1)).getLanguages();
+    }
+
+    @Test
+    public void shouldGetLanguageOrDefaultForSpecifiedLocaleFromApplicationLanguages() {
+        when(mockLanguages.getLanguageOrDefault(EXPECTED_LANGUAGE)).thenReturn(EXPECTED_LANGUAGE);
+
+        templateEngine.init(mockApplication);
+
+        String language = templateEngine.getLanguageOrDefault(EXPECTED_LANGUAGE);
+
+        assertThat(language, is(EXPECTED_LANGUAGE));
+
+        verify(mockLanguages, times(1)).getLanguageOrDefault(EXPECTED_LANGUAGE);
+        verify(mockApplication, times(1)).getLanguages();
+    }
+
+    @Test
+    public void shouldGetLanguageOrDefaultForSpecifiedRouteContextFromApplicationLanguages() {
+        RouteContext routeContext = mock(RouteContext.class);
+
+        when(mockLanguages.getLanguageOrDefault(any(RouteContext.class))).thenReturn(EXPECTED_LANGUAGE);
+
+        templateEngine.init(mockApplication);
+
+        String language = templateEngine.getLanguageOrDefault(routeContext);
+
+        assertThat(language, is(EXPECTED_LANGUAGE));
+
+        verify(mockLanguages, times(1)).getLanguageOrDefault(eq(routeContext));
+        verify(mockApplication, times(1)).getLanguages();
+    }
+
+    @Test
+    public void shouldReturnApplicationMessages() {
+        templateEngine.init(mockApplication);
+
+        Messages messages = templateEngine.getMessages();
+
+        assertThat(messages, is(mockMessages));
+
+        verify(mockApplication, times(1)).getMessages();
+    }
+
+    @Test
+    public void shouldReturnApplicationSettings() {
+        templateEngine.init(mockApplication);
+
+        PippoSettings pippoSettings = templateEngine.getPippoSettings();
+
+        assertThat(pippoSettings, is(mockPippoSettings));
+
+        verify(mockApplication, times(1)).getPippoSettings();
+    }
+
+    @Test
+    public void shouldReturnApplicationRouter() {
+        templateEngine.init(mockApplication);
+
+        Router router = templateEngine.getRouter();
+
+        assertThat(router, is(mockRouter));
+
+        verify(mockApplication, times(1)).getRouter();
+    }
+
+    @Test
+    public void shouldReturnDefaultTemplateFileExtensionIfNotConfiguredInSettings() {
+        when(mockPippoSettings.getString(anyString(), anyString()))
+            .then(args -> args.getArgumentAt(1, String.class));
+
+        templateEngine.init(mockApplication);
+
+        String fileExtension = templateEngine.getFileExtension();
+
+        assertThat(fileExtension, is(EXPECTED_DEFAULT_FILE_EXTENSION));
+
+        verify(mockPippoSettings, times(1))
+            .getString(eq(PippoConstants.SETTING_TEMPLATE_EXTENSION), eq(EXPECTED_DEFAULT_FILE_EXTENSION));
+    }
+
+    @Test
+    public void shouldReturnTemplateFileExtensionConfiguredInSettings() {
+        when(mockPippoSettings.getString(anyString(), anyString())).thenReturn(EXPECTED_FILE_EXTENSION);
+
+        templateEngine.init(mockApplication);
+
+        String fileExtension = templateEngine.getFileExtension();
+
+        assertThat(fileExtension, is(EXPECTED_FILE_EXTENSION));
+
+        verify(mockPippoSettings, times(1))
+            .getString(eq(PippoConstants.SETTING_TEMPLATE_EXTENSION), eq(EXPECTED_DEFAULT_FILE_EXTENSION));
+    }
+
+    @Test
+    public void shouldReturnDefaultTemplatePathPrefixIfNotConfiguredInSettings() {
+        when(mockPippoSettings.getString(anyString(), anyString()))
+            .then(args -> args.getArgumentAt(1, String.class));
+
+        templateEngine.init(mockApplication);
+
+        String templatePathPrefix = templateEngine.getTemplatePathPrefix();
+
+        assertThat(templatePathPrefix, is(TemplateEngine.DEFAULT_PATH_PREFIX));
+
+        verify(mockPippoSettings, times(1))
+            .getString(eq(PippoConstants.SETTING_TEMPLATE_PATH_PREFIX), eq(TemplateEngine.DEFAULT_PATH_PREFIX));
+    }
+
+    @Test
+    public void shouldReturnTemplatePathPrefixConfiguredInSettings() {
+        when(mockPippoSettings.getString(anyString(), anyString()))
+            .thenReturn(EXPECTED_TEMPLATE_PATH_PREFIX);
+
+        templateEngine.init(mockApplication);
+
+        String templatePathPrefix = templateEngine.getTemplatePathPrefix();
+
+        assertThat(templatePathPrefix, is(EXPECTED_TEMPLATE_PATH_PREFIX));
+
+        verify(mockPippoSettings, times(1))
+            .getString(eq(PippoConstants.SETTING_TEMPLATE_PATH_PREFIX), eq(TemplateEngine.DEFAULT_PATH_PREFIX));
+    }
+
+    @After
+    public void tearDown() {
+        reset(mockApplication);
+        reset(mockLanguages);
+    }
+
+    private static class TestTemplateEngine extends AbstractTemplateEngine<String> {
+
+        @Override
+        public void init(Application application) {
+            super.init(application);
+        }
+
+        @Override
+        public void renderString(String templateContent, Map<String, Object> model, Writer writer) {
+
+        }
+
+        @Override
+        public void renderResource(String templateName, Map<String, Object> model, Writer writer) {
+
+        }
+
+        @Override
+        protected String getDefaultFileExtension() {
+            return EXPECTED_DEFAULT_FILE_EXTENSION;
+        }
+    }
+}

--- a/pippo-template-parent/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
+++ b/pippo-template-parent/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
@@ -43,7 +43,7 @@ import java.util.Map;
  * @author James Moger
  */
 @MetaInfServices
-public class PebbleTemplateEngine extends AbstractTemplateEngine<PebbleEngine.Builder> {
+public class PebbleTemplateEngine extends AbstractTemplateEngine {
 
     private final Logger log = LoggerFactory.getLogger(PebbleTemplateEngine.class);
 
@@ -91,7 +91,6 @@ public class PebbleTemplateEngine extends AbstractTemplateEngine<PebbleEngine.Bu
         engine = builder.build();
     }
 
-    @Override
     protected void init(Application application, PebbleEngine.Builder configurationTarget) {
         // NO OP
     }

--- a/pippo-template-parent/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
+++ b/pippo-template-parent/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
@@ -58,7 +58,7 @@ public class PebbleTemplateEngine implements TemplateEngine {
 
     private PebbleEngine engine;
 
-    private String extension = PEBBLE;
+    private String extension;
 
     @Override
     public void init(Application application) {
@@ -74,6 +74,9 @@ public class PebbleTemplateEngine implements TemplateEngine {
 
         List<Loader<?>> loaders = Lists.newArrayList();
         PippoTemplateLoader templateLoader = new PippoTemplateLoader();
+
+        extension = pippoSettings.getString(PippoConstants.SETTING_TEMPLATE_EXTENSION, PEBBLE);
+
         templateLoader.setCharset(PippoConstants.UTF8);
         templateLoader.setPrefix(pathPrefix);
         templateLoader.setSuffix("." + extension);

--- a/pippo-template-parent/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
+++ b/pippo-template-parent/pippo-pebble/src/main/java/ro/pippo/pebble/PebbleTemplateEngine.java
@@ -28,12 +28,7 @@ import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ro.pippo.core.Application;
-import ro.pippo.core.Languages;
-import ro.pippo.core.PippoConstants;
-import ro.pippo.core.PippoRuntimeException;
-import ro.pippo.core.PippoSettings;
-import ro.pippo.core.TemplateEngine;
+import ro.pippo.core.*;
 import ro.pippo.core.route.Router;
 import ro.pippo.core.util.StringUtils;
 
@@ -48,38 +43,27 @@ import java.util.Map;
  * @author James Moger
  */
 @MetaInfServices
-public class PebbleTemplateEngine implements TemplateEngine {
+public class PebbleTemplateEngine extends AbstractTemplateEngine<PebbleEngine.Builder> {
 
     private final Logger log = LoggerFactory.getLogger(PebbleTemplateEngine.class);
 
-    public static final String PEBBLE = "peb";
-
-    private Languages languages;
+    private static final String PEBBLE = "peb";
 
     private PebbleEngine engine;
 
-    private String extension;
-
     @Override
     public void init(Application application) {
-        this.languages = application.getLanguages();
+        super.init(application);
 
-        Router router = application.getRouter();
-        PippoSettings pippoSettings = application.getPippoSettings();
-
-        String pathPrefix = pippoSettings.getString(PippoConstants.SETTING_TEMPLATE_PATH_PREFIX, null);
-        if (StringUtils.isNullOrEmpty(pathPrefix)) {
-            pathPrefix = TemplateEngine.DEFAULT_PATH_PREFIX;
-        }
+        Router router = getRouter();
+        PippoSettings pippoSettings = getPippoSettings();
 
         List<Loader<?>> loaders = Lists.newArrayList();
         PippoTemplateLoader templateLoader = new PippoTemplateLoader();
 
-        extension = pippoSettings.getString(PippoConstants.SETTING_TEMPLATE_EXTENSION, PEBBLE);
-
         templateLoader.setCharset(PippoConstants.UTF8);
-        templateLoader.setPrefix(pathPrefix);
-        templateLoader.setSuffix("." + extension);
+        templateLoader.setPrefix(getTemplatePathPrefix());
+        templateLoader.setSuffix("." + getFileExtension());
         loaders.add(templateLoader);
 
         PebbleEngine.Builder builder = new PebbleEngine.Builder()
@@ -108,14 +92,20 @@ public class PebbleTemplateEngine implements TemplateEngine {
     }
 
     @Override
+    protected void init(Application application, PebbleEngine.Builder configurationTarget) {
+        // NO OP
+    }
+
+    @Override
     public void renderString(String templateContent, Map<String, Object> model, Writer writer) {
         String language = (String) model.get(PippoConstants.REQUEST_PARAMETER_LANG);
+
         if (StringUtils.isNullOrEmpty(language)) {
-            language = languages.getLanguageOrDefault(language);
+            language = getLanguageOrDefault(language);
         }
         Locale locale = (Locale) model.get(PippoConstants.REQUEST_PARAMETER_LOCALE);
         if (locale == null) {
-            locale = languages.getLocaleOrDefault(language);
+            locale = getLocaleOrDefault(language);
         }
 
         try {
@@ -136,16 +126,19 @@ public class PebbleTemplateEngine implements TemplateEngine {
     @Override
     public void renderResource(String templateName, Map<String, Object> model, Writer writer) {
         String language = (String) model.get(PippoConstants.REQUEST_PARAMETER_LANG);
+
         if (StringUtils.isNullOrEmpty(language)) {
-            language = languages.getLanguageOrDefault(language);
+            language = getLanguageOrDefault(language);
         }
+
         Locale locale = (Locale) model.get(PippoConstants.REQUEST_PARAMETER_LOCALE);
         if (locale == null) {
-            locale = languages.getLocaleOrDefault(language);
+            locale = getLocaleOrDefault(language);
         }
 
         try {
             PebbleTemplate template = null;
+
             if (locale != null) {
                 // try the complete Locale
                 template = getTemplate(templateName, locale.toString());
@@ -168,11 +161,8 @@ public class PebbleTemplateEngine implements TemplateEngine {
     }
 
     @Override
-    public void setFileExtension(String extension) {
-        this.extension = extension;
-    }
-
-    protected void init(Application application, PebbleEngine.Builder builder) {
+    protected String getDefaultFileExtension() {
+        return PEBBLE;
     }
 
     private PebbleTemplate getTemplate(String templateName, String localePart) throws PebbleException {
@@ -181,7 +171,8 @@ public class PebbleTemplateEngine implements TemplateEngine {
             if (Strings.isNullOrEmpty(localePart)) {
                 template = engine.getTemplate(templateName);
             } else {
-                String localizedName = StringUtils.removeEnd(templateName, "." + extension) + "_" + localePart;
+                String localizedName = StringUtils.removeEnd(templateName, "." +
+                    getFileExtension()) + "_" + localePart;
                 template = engine.getTemplate(localizedName);
             }
         } catch (LoaderException e) {


### PR DESCRIPTION
This change allows customizing the file extension used by `PebbleTemplateEngine` from the default of `.peb`. The customization can be applied by adding the following line in `conf/application.properties`:

```properties
template.extension = pebble
```

The same can be used by other pippo template integrations.