### PR TITLE
Add path params in websocket uri

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pippo-controller-parent/pippo-controller/src/main/java/ro/pippo/controller/ControllerRegistry.java
+++ b/pippo-controller-parent/pippo-controller/src/main/java/ro/pippo/controller/ControllerRegistry.java
@@ -271,7 +271,7 @@ public class ControllerRegistry {
         Map<Method, Class<? extends Annotation>> controllerMethods = new LinkedHashMap<>();
 
         // discover all annotated controllers methods
-        for (Method method : controllerClass.getDeclaredMethods()) {
+        for (Method method : ClassUtils.getDeclaredMethods(controllerClass)) {
             for (Annotation annotation : method.getAnnotations()) {
                 Class<? extends Annotation> annotationClass = annotation.annotationType();
                 if (httpMethodAnnotationClasses.contains(annotationClass)) {

--- a/pippo-controller-parent/pippo-controller/src/main/java/ro/pippo/controller/util/ClassUtils.java
+++ b/pippo-controller-parent/pippo-controller/src/main/java/ro/pippo/controller/util/ClassUtils.java
@@ -32,6 +32,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -160,6 +161,31 @@ public class ClassUtils {
         return getAnnotation(objectClass.getSuperclass(), annotationClass);
     }
 
+    /**
+     * Returns an array containing {@code Method} objects reflecting all the
+     * declared methods of the class or interface represented by this {@code
+     * Class} object, including public, protected, default (package)
+     * access, and private methods, <b>but excluding inherited methods</b>.
+     * 
+     * <p>This method differs from {@link Class#getDeclaredMethods()} since it
+     * does <b>not return bridge methods</b>, in other words, only the methods of
+     * the class are returned. <b>If you just want the methods declared in
+     * {@code clazz} use this method!</b></p>
+     * 
+     * @param clazz Class
+     * 
+     * @return the array of {@code Method} objects representing all the
+     *          declared methods of this class
+     * 
+     * @see Class#getDeclaredMethods()
+     */
+    public static List<Method> getDeclaredMethods(Class<?> clazz) {
+        return Arrays
+                .stream(clazz.getDeclaredMethods())
+                .filter(method -> !method.isBridge())
+                .collect(Collectors.toList());
+    }
+    
     public static <T extends Annotation> List<T> collectNestedAnnotation(Method method, Class<T> annotationClass) {
         List<T> list = new ArrayList<>();
         for (Annotation annotation : method.getDeclaredAnnotations()) {

--- a/pippo-core/src/main/java/ro/pippo/core/Application.java
+++ b/pippo-core/src/main/java/ro/pippo/core/Application.java
@@ -33,6 +33,7 @@ import ro.pippo.core.util.HttpCacheToolkit;
 import ro.pippo.core.util.MimeTypes;
 import ro.pippo.core.util.ServiceLocator;
 import ro.pippo.core.websocket.WebSocketHandler;
+import ro.pippo.core.websocket.WebSocketRouter;
 
 import javax.servlet.ServletContext;
 import java.util.ArrayList;
@@ -74,7 +75,7 @@ public class Application implements ResourceRouting {
     private Map<String, Object> locals;
     private RouteHandler notFoundRouteHandler;
 
-    private Map<String, WebSocketHandler> webSocketHandlers;
+    private WebSocketRouter webSocketRouter;
 
     public Application() {
         this(new PippoSettings(RuntimeMode.getCurrent()));
@@ -88,7 +89,7 @@ public class Application implements ResourceRouting {
         this.httpCacheToolkit = new HttpCacheToolkit(settings);
         this.engines = new ContentTypeEngines();
         this.initializers = new ArrayList<>();
-        this.webSocketHandlers = new HashMap<>();
+        this.webSocketRouter = new WebSocketRouter();
 
         registerContentTypeEngine(TextPlainEngine.class);
     }
@@ -375,12 +376,12 @@ public class Application implements ResourceRouting {
         return notFoundRouteHandler;
     }
 
-    public void addWebSocket(String path, WebSocketHandler webSocketHandler) {
-        webSocketHandlers.put(path, webSocketHandler);
+    public void addWebSocket(String uriPattern, WebSocketHandler webSocketHandler) {
+        webSocketRouter.addRoute(uriPattern, webSocketHandler);
     }
 
-    public WebSocketHandler getWebSocketHandler(String path) {
-        return webSocketHandlers.get(path);
+    public WebSocketRouter getWebSocketRouter() {
+        return webSocketRouter;
     }
 
     /**

--- a/pippo-core/src/main/java/ro/pippo/core/DefaultUriMatcher.java
+++ b/pippo-core/src/main/java/ro/pippo/core/DefaultUriMatcher.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Decebal Suiu
+ */
+public class DefaultUriMatcher implements UriMatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultUriMatcher.class);
+
+    // Matches: {id} AND {id: .*?}
+    // group(1) extracts the name of the group (in that case "id").
+    // group(3) extracts the regex if defined
+    private static final Pattern PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE = Pattern.compile("\\{(.*?)(:\\s(.*?))?\\}");
+
+    // This regex matches everything in between path slashes.
+    private static final String VARIABLE_ROUTES_DEFAULT_REGEX = "(?<%s>[^/]+)";
+
+    // This regex works for both {myParam} AND {myParam: .*}
+    private static final String VARIABLE_PART_PATTERN_WITH_PLACEHOLDER = "\\{(%s)(:\\s([^}]*))?\\}";
+
+    private static final String PATH_PARAMETER_REGEX_GROUP_NAME_PREFIX = "param";
+
+    // key = uri pattern
+    private Map<String, UriPatternBinding> bindings;
+
+    public DefaultUriMatcher() {
+        bindings = new HashMap<>();
+    }
+
+    @Override
+    public Map<String, String> match(String requestUri, String uriPattern) {
+        UriPatternBinding binding = bindings.get(uriPattern);
+        if (binding == null) {
+            // something is wrong
+            throw new PippoRuntimeException("No binding for '{}'. Create binding with 'addUriPattern'.", uriPattern);
+        }
+
+        return binding.getPattern().matcher(requestUri).matches() ? getParameters(binding, requestUri) : null;
+    }
+
+    @Override
+    public UriPatternBinding addUriPattern(String uriPattern) {
+        if (bindings.containsKey(uriPattern)) {
+            return bindings.get(uriPattern);
+        }
+
+        String regex = getRegex(uriPattern);
+        Pattern pattern = Pattern.compile(regex);
+        List<String> parameterNames = getParameterNames(uriPattern);
+        UriPatternBinding binding = new UriPatternBinding(uriPattern, pattern, parameterNames);
+        bindings.put(uriPattern, binding);
+        log.debug("Add binding '{}'", binding);
+
+        return binding;
+    }
+
+    @Override
+    public UriPatternBinding removeUriPattern(String uriPattern) {
+        return bindings.remove(uriPattern);
+    }
+
+    @Override
+    public String uriFor(Map<String, Object> parameters, String uriPattern) {
+        UriPatternBinding binding = bindings.get(uriPattern);
+        if (binding == null) {
+            // something is wrong
+            throw new PippoRuntimeException("No binding for '{}'. Create binding with 'addUriPattern'.", uriPattern);
+        }
+
+        List<String> parameterNames = binding.getParameterNames();
+        if (!parameters.keySet().containsAll(parameterNames)) {
+            log.error("You must provide values for all path parameters. {} vs {}", parameterNames, parameters.keySet());
+        }
+
+        Map<String, Object> queryParameters = new HashMap<>(parameters.size());
+
+        // create a uri starting from uriPattern (that can contains path params placeholders)
+        String uri = binding.getUriPattern();
+
+        // replace path params placeholders from uri pattern
+        for (Map.Entry<String, Object> parameterPair : parameters.entrySet()) {
+            boolean foundAsPathParameter = false;
+
+            StringBuffer sb = new StringBuffer();
+            String regex = String.format(VARIABLE_PART_PATTERN_WITH_PLACEHOLDER, parameterPair.getKey());
+            Pattern pattern = Pattern.compile(regex);
+            Matcher matcher = pattern.matcher(uri);
+            while (matcher.find()) {
+                matcher.appendReplacement(sb, getPathParameterValue(uriPattern, parameterPair.getKey(), parameterPair.getValue()));
+                foundAsPathParameter = true;
+            }
+
+            matcher.appendTail(sb);
+            uri = sb.toString();
+
+            if (!foundAsPathParameter) {
+                queryParameters.put(parameterPair.getKey(), parameterPair.getValue());
+            }
+        }
+
+        // prepare the query string for this url if we got some query params
+        if (!queryParameters.isEmpty()) {
+            // add remaining parameters as query parameters
+            StringBuilder query = new StringBuilder();
+            Iterator<Map.Entry<String, Object>> iterator = queryParameters.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<String, Object> parameterEntry = iterator.next();
+                String parameterName = parameterEntry.getKey();
+                Object parameterValue = parameterEntry.getValue();
+                String encodedParameterValue;
+                try {
+                    encodedParameterValue = URLEncoder.encode(parameterValue.toString(), PippoConstants.UTF8);
+                } catch (UnsupportedEncodingException e) {
+                    throw new PippoRuntimeException(e, "Cannot encode the parameter value '{}'", parameterValue.toString());
+                }
+                query.append(parameterName).append("=").append(encodedParameterValue);
+
+                if (iterator.hasNext()) {
+                    query.append("&");
+                }
+            }
+
+            uri += "?" + query;
+        }
+
+        return uri;
+    }
+
+    protected String getPathParameterValue(String uriPattern, String parameterName, Object parameterValue) {
+        return parameterValue.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> getParameters(UriPatternBinding binding, String requestUri) {
+        List<String> parameterNames = binding.getParameterNames();
+        if (parameterNames.isEmpty()) {
+            return Collections.EMPTY_MAP;
+        }
+
+        Map<String, String> parameters = new HashMap<>();
+        Matcher matcher = binding.getPattern().matcher(requestUri);
+        matcher.matches(); // always true
+        int groupCount = matcher.groupCount();
+        if (groupCount > 0) {
+            for (int i = 0; i < parameterNames.size(); i++) {
+                parameters.put(parameterNames.get(i), matcher.group(getPathParameterRegexGroupName(i)));
+            }
+        }
+
+        return parameters;
+    }
+
+    /**
+     * Transforms an url pattern like "/{name}/id/*" into a regex like "/([^/]*)/id/*."
+     * <p/>
+     * Also handles regular expressions if defined inside routes:
+     * For instance "/users/{username: [a-zA-Z][a-zA-Z_0-9]}" becomes
+     * "/users/([a-zA-Z][a-zA-Z_0-9])"
+     *
+     * @return The converted regex with default matching regex - or the regex
+     * specified by the user.
+     */
+    private String getRegex(String urlPattern) {
+        StringBuffer buffer = new StringBuffer();
+
+        Matcher matcher = PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE.matcher(urlPattern);
+        int pathParameterIndex = 0;
+        while (matcher.find()) {
+            // By convention group 3 is the regex if provided by the user.
+            // If it is not provided by the user the group 3 is null.
+            String namedVariablePartOfRoute = matcher.group(3);
+            String namedVariablePartOfORouteReplacedWithRegex;
+
+            if (namedVariablePartOfRoute != null) {
+                // we convert that into a regex matcher group itself
+                String variableRegex = replacePosixClasses(namedVariablePartOfRoute);
+                namedVariablePartOfORouteReplacedWithRegex = String.format("(?<%s>%s)",
+                    getPathParameterRegexGroupName(pathParameterIndex), Matcher.quoteReplacement(variableRegex));
+            } else {
+                // we convert that into the default namedVariablePartOfRoute regex group
+                namedVariablePartOfORouteReplacedWithRegex = String.format(VARIABLE_ROUTES_DEFAULT_REGEX,
+                    getPathParameterRegexGroupName(pathParameterIndex));
+            }
+            // we replace the current namedVariablePartOfRoute group
+            matcher.appendReplacement(buffer, namedVariablePartOfORouteReplacedWithRegex);
+            pathParameterIndex++;
+        }
+
+        // .. and we append the tail to complete the stringBuffer
+        matcher.appendTail(buffer);
+
+        return buffer.toString();
+    }
+
+    private String getPathParameterRegexGroupName(int pathParameterIndex) {
+        return PATH_PARAMETER_REGEX_GROUP_NAME_PREFIX + pathParameterIndex;
+    }
+
+    /**
+     * Replace any specified POSIX character classes with the Java equivalent.
+     *
+     * @param input
+     * @return a Java regex
+     */
+    private String replacePosixClasses(String input) {
+        return input
+            .replace(":alnum:", "\\p{Alnum}")
+            .replace(":alpha:", "\\p{L}")
+            .replace(":ascii:", "\\p{ASCII}")
+            .replace(":digit:", "\\p{Digit}")
+            .replace(":xdigit:", "\\p{XDigit}");
+    }
+
+    /**
+     * Extracts the name of the parameters from a route
+     * <p/>
+     * /{my_id}/{my_name}
+     * <p/>
+     * would return a List with "my_id" and "my_name"
+     *
+     * @param uriPattern
+     * @return a list with the names of all parameters in the url pattern
+     */
+    private List<String> getParameterNames(String uriPattern) {
+        List<String> list = new ArrayList<>();
+
+        Matcher matcher = PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE.matcher(uriPattern);
+        while (matcher.find()) {
+            // group(1) is the name of the group. Must be always there...
+            // "/assets/{file}" and "/assets/{file: [a-zA-Z][a-zA-Z_0-9]}"
+            // will return file.
+            list.add(matcher.group(1));
+        }
+
+        return list;
+    }
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java
+++ b/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java
@@ -29,6 +29,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -239,15 +240,11 @@ public class ParameterValue implements Serializable {
     }
 
     public Set<String> toSet(Set<String> defaultValue) {
-        if (isNull() || (values.length == 1 && StringUtils.isNullOrEmpty(values[0]))) {
+        List<String> list = toList();
+        if (list.isEmpty()) {
             return defaultValue;
         }
-
-        if (values.length == 1) {
-            return new HashSet<>(Arrays.asList(values[0].split(",")));
-        }
-
-        return new HashSet<>(Arrays.asList(values));
+        return new HashSet<>(list);
     }
 
     /**
@@ -274,7 +271,7 @@ public class ParameterValue implements Serializable {
     }
 
     public List<String> toList() {
-        return toList(new ArrayList<String>());
+        return toList(Collections.emptyList());
     }
 
     public List<String> toList(List<String> defaultValue) {
@@ -287,7 +284,7 @@ public class ParameterValue implements Serializable {
             tmp = StringUtils.removeStart(tmp, "[");
             tmp = StringUtils.removeEnd(tmp, "]");
 
-            return Arrays.asList(tmp.split("(,|\\|)"));
+            return StringUtils.getList(tmp, "(,|\\|)");
         }
 
         return Arrays.asList(values);
@@ -375,32 +372,17 @@ public class ParameterValue implements Serializable {
 
         if (classOfT.isArray()) {
             Class<?> componentType = classOfT.getComponentType();
-            Object array;
             // cheat by not instantiating a ParameterValue for every value
             ParameterValue parameterValue = new ParameterValue("PLACEHOLDER");
-            if (values.length == 1) {
-                // split a single-value list into an array
-                String tmp = values[0];
-                tmp = StringUtils.removeStart(tmp, "[");
-                tmp = StringUtils.removeEnd(tmp, "]");
-                List<String> list = StringUtils.getList(tmp, "(,|\\|)");
-                array = Array.newInstance(componentType, list.size());
-                for (int i = 0; i < list.size(); i++) {
-                    String value = list.get(i);
-                    parameterValue.values[0] = value;
-                    Object object = parameterValue.toObject(componentType, pattern);
-                    Array.set(array, i, object);
-                }
-            } else {
-                array = Array.newInstance(componentType, values.length);
-                for (int i = 0; i < values.length; i++) {
-                    String value = values[i];
-                    parameterValue.values[0] = value;
-                    Object object = parameterValue.toObject(componentType, pattern);
-                    Array.set(array, i, object);
-                }
-            }
+            List<String> list = toList();
+            Object array = Array.newInstance(componentType, list.size());
 
+            for (int i = 0; i < list.size(); i++) {
+                String value = list.get(i);
+                parameterValue.values[0] = value;
+                Object object = parameterValue.toObject(componentType, pattern);
+                Array.set(array, i, object);
+            }
             return (T) array;
         } else {
             return (T) toObject(classOfT, pattern);
@@ -431,15 +413,7 @@ public class ParameterValue implements Serializable {
             // cheat by not instantiating a ParameterValue for every value
             ParameterValue parameterValue = new ParameterValue("PLACEHOLDER");
 
-            List<String> list;
-            if (values.length == 1) {
-                String tmp = values[0];
-                tmp = StringUtils.removeStart(tmp, "[");
-                tmp = StringUtils.removeEnd(tmp, "]");
-                list = StringUtils.getList(tmp, "(,|\\|)");
-            } else {
-                list = Arrays.asList(values);
-            }
+            List<String> list = toList();
 
             for (String value : list) {
                 parameterValue.values[0] = value;

--- a/pippo-core/src/main/java/ro/pippo/core/UriMatcher.java
+++ b/pippo-core/src/main/java/ro/pippo/core/UriMatcher.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * @author Decebal Suiu
+ */
+public interface UriMatcher {
+
+    /**
+     * Returns null for no matching and not null for matching.
+     * The returned map represent the path parameters.
+     *
+     * @param requestUri
+     * @param uriPattern
+     * @return
+     */
+    Map<String, String> match(String requestUri, String uriPattern);
+
+    UriPatternBinding addUriPattern(String uriPattern);
+
+    UriPatternBinding removeUriPattern(String uriPattern);
+
+    String uriFor(Map<String, Object> parameters, String uriPattern);
+
+    class UriPatternBinding {
+
+        private final String uriPattern;
+        private final Pattern pattern;
+        private final List<String> parameterNames;
+
+        public UriPatternBinding(String uriPattern, Pattern pattern, List<String> parameterNames) {
+            this.uriPattern = uriPattern;
+            this.pattern = pattern;
+            this.parameterNames = parameterNames;
+        }
+
+        public String getUriPattern() {
+            return uriPattern;
+        }
+
+        public Pattern getPattern() {
+            return pattern;
+        }
+
+        public List<String> getParameterNames() {
+            return parameterNames;
+        }
+
+        @Override
+        public String toString() {
+            return "UriPatternBinding{" +
+                "uriPattern=" + uriPattern +
+                ", pattern=" + pattern +
+                ", parameterNames=" + parameterNames +
+                '}';
+        }
+
+    }
+
+}

--- a/pippo-core/src/main/java/ro/pippo/core/UriMatcher.java
+++ b/pippo-core/src/main/java/ro/pippo/core/UriMatcher.java
@@ -20,13 +20,18 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
+ * {@code UriMatcher} provides the functionality of comparing a given {@code requestUri}
+ * with a {@code uriPattern}.
+ *
  * @author Decebal Suiu
  */
 public interface UriMatcher {
 
     /**
-     * Returns null for no matching and not null for matching.
-     * The returned map represent the path parameters.
+     * Returns {@code null} for no matching and {@code not null} for matching.
+     * The returned map represent the path parameters (the key is the parameter name
+     * and the value is parameter value). The returned map is empty for matching but
+     * without parameters.
      *
      * @param requestUri
      * @param uriPattern

--- a/pippo-core/src/main/java/ro/pippo/core/route/Routing.java
+++ b/pippo-core/src/main/java/ro/pippo/core/route/Routing.java
@@ -79,6 +79,13 @@ public interface Routing {
         return route;
     }
 
+    default Route OPTIONS(String uriPattern, RouteHandler routeHandler) {
+        Route route = Route.OPTIONS(uriPattern, routeHandler);
+        addRoute(route);
+
+        return route;
+    }
+
     /**
      * @deprecated Replaced by {@link #ANY(String, RouteHandler)}.
      */

--- a/pippo-core/src/main/java/ro/pippo/core/websocket/AbstractWebSocketFilter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/websocket/AbstractWebSocketFilter.java
@@ -132,15 +132,14 @@ public abstract class AbstractWebSocketFilter extends PippoFilter {
         return null;
     }
 
-    protected WebSocketHandler getWebSocketHandler(String requestUri) {
+    protected WebSocketRouter.WebSocketMatch findWebSocketRoute(String requestUri) {
         String applicationPath = getApplication().getRouter().getContextPath();
         String path = applicationPath.isEmpty() ? requestUri : requestUri.substring(applicationPath.length());
         if (StringUtils.isNullOrEmpty(path)) {
             path = "/";
         }
 
-        return getApplication().getWebSocketHandler(path);
-
+        return getApplication().getWebSocketRouter().match(path);
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketContext.java
+++ b/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketContext.java
@@ -15,8 +15,12 @@
  */
 package ro.pippo.core.websocket;
 
+import ro.pippo.core.ParameterValue;
+
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Used for accessing the current client connection and all clients connections.
@@ -27,12 +31,19 @@ import java.util.List;
  */
 public class WebSocketContext {
 
-    private final WebSocketConnection connection;
     private final List<WebSocketConnection> connections;
+    private final WebSocketConnection connection;
+    private final Map<String, ParameterValue> pathParameters;
 
-    public WebSocketContext(List<WebSocketConnection> connections, WebSocketConnection connection) {
+
+    public WebSocketContext(List<WebSocketConnection> connections, WebSocketConnection connection, Map<String, String> pathParameters) {
         this.connections = connections;
         this.connection = connection;
+
+        this.pathParameters = new HashMap<>(pathParameters.size());
+        for (String name : pathParameters.keySet()) {
+            this.pathParameters.put(name, new ParameterValue(pathParameters.get(name)));
+        }
     }
 
     public WebSocketConnection getConnection() {
@@ -51,6 +62,24 @@ public class WebSocketContext {
         for (WebSocketConnection connection : connections) {
             connection.sendMessage(message);
         }
+    }
+
+    /**
+     * Returns all path parameters.
+     */
+    public Map<String, ParameterValue> getPathParameters() {
+        return pathParameters;
+    }
+
+    /**
+     * Returns one path parameter.
+     */
+    public ParameterValue getPathParameter(String name) {
+        if (!getPathParameters().containsKey(name)) {
+            return new ParameterValue();
+        }
+
+        return getPathParameters().get(name);
     }
 
 }

--- a/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketRouter.java
+++ b/pippo-core/src/main/java/ro/pippo/core/websocket/WebSocketRouter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core.websocket;
+
+import ro.pippo.core.DefaultUriMatcher;
+import ro.pippo.core.UriMatcher;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Decebal Suiu
+ */
+public class WebSocketRouter {
+
+    // key = uri pattern
+    private Map<String, WebSocketHandler> handlers;
+
+    private UriMatcher uriMatcher;
+
+    public WebSocketRouter() {
+        handlers = new HashMap<>();
+        uriMatcher = new DefaultUriMatcher();
+    }
+
+    public WebSocketMatch match(String requestUri) {
+        for (String uriPattern : handlers.keySet()) {
+            Map<String, String> pathParameters = uriMatcher.match(requestUri, uriPattern);
+            if (pathParameters != null) {
+                return new WebSocketMatch(uriPattern, handlers.get(uriPattern), pathParameters);
+            }
+        }
+
+        // TODO
+        return null;
+    }
+
+    public void addRoute(String uriPattern, WebSocketHandler handler) {
+        handlers.put(uriPattern, handler);
+        uriMatcher.addUriPattern(uriPattern);
+    }
+
+    public static class WebSocketMatch {
+
+        private final String uriPattern;
+        private final WebSocketHandler handler;
+        private final Map<String, String> pathParameters;
+
+        public WebSocketMatch(String uriPattern, WebSocketHandler handler, Map<String, String> pathParameters) {
+            this.uriPattern = uriPattern;
+            this.handler = handler;
+            this.pathParameters = pathParameters;
+        }
+
+        public String getUriPattern() {
+            return uriPattern;
+        }
+
+        public WebSocketHandler getHandler() {
+            return handler;
+        }
+
+        public Map<String, String> getPathParameters() {
+            return pathParameters;
+        }
+
+    }
+
+}

--- a/pippo-core/src/main/resources/pippo/pippo-messages_pl.properties
+++ b/pippo-core/src/main/resources/pippo/pippo-messages_pl.properties
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+pippo.statusCode200 = OK
+pippo.statusCode201 = Stworzono
+pippo.statusCode202 = Zaakceptowano
+pippo.statusCode203 = Informacje czesciowe
+pippo.statusCode204 = Brak odpowiedzi
+pippo.statusCode400 = Zle zapytanie
+pippo.statusCode401 = Blad autoryzacji
+pippo.statusCode402 = Platnosc wymagana
+pippo.statusCode403 = Dostep zabroniony
+pippo.statusCode404 = Nie znaleziono
+pippo.statusCode405 = Metoda niedozwolona
+pippo.statusCode409 = Konflikt
+pippo.statusCode410 = Stracony
+pippo.statusCode500 = Wewnetrzny blad
+pippo.statusCode501 = Nie zaimplementowano
+pippo.statusCode502 = Przeciazony

--- a/pippo-core/src/test/java/ro/pippo/core/DefaultErrorHandlerTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/DefaultErrorHandlerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import ro.pippo.core.route.RouteContext;
+
+/**
+ * @author Tim Hinkes
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultErrorHandlerTest {
+    private DefaultErrorHandler defaultErrorHandler;
+    private RouteContext routeContext;
+
+    @Before
+    public void setUp() {
+        Application application = Mockito.mock(Application.class);
+        this.routeContext = Mockito.mock(RouteContext.class);
+        this.defaultErrorHandler = new DefaultErrorHandler(application);
+    }
+
+    //Tests whether a ExceptionHandler for PippoRuntimeExceptions is called
+    //if it is present. (To preserve previous behavior)
+    @Test
+    public void testPippoRuntimeExceptionHandlerCalledIfPResent() {
+        //arrange
+        ExceptionHandler pippoRuntimeExceptionExceptionHandler = Mockito.mock
+            (ExceptionHandler.class);
+        PippoRuntimeException pippoRuntimeException = new
+            PippoRuntimeException("TestException");
+        defaultErrorHandler.setExceptionHandler(PippoRuntimeException.class,
+            pippoRuntimeExceptionExceptionHandler);
+
+        //act
+        defaultErrorHandler.handle(pippoRuntimeException, routeContext);
+
+        //assert
+        Mockito.verify(pippoRuntimeExceptionExceptionHandler, Mockito.times
+            (1)).handle(pippoRuntimeException, routeContext);
+    }
+
+    @Test
+    public void testNestedExceptionHandlerIsCalled() {
+        //arrange
+        ExceptionHandler testExceptionHandler = Mockito.mock
+            (ExceptionHandler.class);
+        TestException nestedTestException = new TestException("TestException");
+        defaultErrorHandler.setExceptionHandler(TestException.class,
+            testExceptionHandler);
+
+        //act
+        defaultErrorHandler.handle(new PippoRuntimeException
+            (nestedTestException), routeContext);
+
+        //assert
+        Mockito.verify(testExceptionHandler, Mockito.times
+            (1)).handle(nestedTestException, routeContext);
+    }
+
+    private class TestException extends Exception {
+        public TestException(final String message) {
+            super(message);
+        }
+    }
+
+}

--- a/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
@@ -223,6 +223,16 @@ public class ParameterValueTest {
     }
 
     @Test
+    public void testHashSet() throws Exception {
+        Set<String> mySet = new HashSet<>(Arrays.asList("200", "400", "600"));
+        assertEquals(mySet, new ParameterValue("600", "200", "400", "200").toSet());
+
+        // when values contains single entry
+        mySet = new HashSet<>(Arrays.asList("200"));
+        assertEquals(mySet, new ParameterValue("200").toSet());
+    }
+
+    @Test
     public void testStringTreeSet() throws Exception {
         TreeSet<String> mySet = new TreeSet<>(Arrays.asList("C", "B", "A"));
         assertEquals(mySet, new ParameterValue("C", "A", "B", "A").toCollection(TreeSet.class, String.class, null));
@@ -293,6 +303,14 @@ public class ParameterValueTest {
     public void testEncodedArray3() throws Exception {
         int [] myArray = { 600, 400, 200 };
         assertTrue(Arrays.equals(myArray, new ParameterValue("600| 400|200").to(int[].class)));
+    }
+
+    @Test
+    public void testEmptyArray() throws Exception {
+        // when parameterValue is empty
+        assertTrue(Arrays.equals(new int[0], new ParameterValue("").to(int[].class)));
+        // when parameterValue is null
+        assertTrue(Arrays.equals(new int[0], new ParameterValue().to(int[].class)));
     }
 
     @Test

--- a/pippo-server-parent/pippo-jetty/src/main/java/ro/pippo/jetty/websocket/JettyWebSocketAdapter.java
+++ b/pippo-server-parent/pippo-jetty/src/main/java/ro/pippo/jetty/websocket/JettyWebSocketAdapter.java
@@ -26,6 +26,7 @@ import ro.pippo.core.websocket.WebSocketHandler;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -41,19 +42,21 @@ public class JettyWebSocketAdapter implements WebSocketListener {
     private static List<WebSocketConnection> connections = new CopyOnWriteArrayList<>();
 
     private final WebSocketHandler handler;
+    private final Map<String, String> pathParameters;
 
     private WebSocketContext context;
     private WebSocketConnection connection;
 
-    public JettyWebSocketAdapter(WebSocketHandler handler) {
+    public JettyWebSocketAdapter(WebSocketHandler handler, Map<String, String> pathParameters) {
         this.handler = handler;
+        this.pathParameters = pathParameters;
     }
 
     @Override
     public void onWebSocketConnect(Session session) {
         connection = new JettyWebSocketConnection(session);
         connections.add(connection);
-        context = new WebSocketContext(connections, connection);
+        context = new WebSocketContext(connections, connection, pathParameters);
 
         handler.onOpen(context);
     }

--- a/pippo-server-parent/pippo-jetty/src/main/java/ro/pippo/jetty/websocket/JettyWebSocketFilter.java
+++ b/pippo-server-parent/pippo-jetty/src/main/java/ro/pippo/jetty/websocket/JettyWebSocketFilter.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import ro.pippo.core.Request;
 import ro.pippo.core.Response;
 import ro.pippo.core.websocket.AbstractWebSocketFilter;
-import ro.pippo.core.websocket.WebSocketHandler;
+import ro.pippo.core.websocket.WebSocketRouter;
 
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
@@ -90,11 +90,9 @@ public class JettyWebSocketFilter extends AbstractWebSocketFilter {
     }
 
     protected JettyWebSocketAdapter createWebSocketAdapter(ServletUpgradeRequest request) {
-        return new JettyWebSocketAdapter(getWebSocketHandler(request));
-    }
+        WebSocketRouter.WebSocketMatch match = findWebSocketRoute(request.getRequestPath());
 
-    private WebSocketHandler getWebSocketHandler(ServletUpgradeRequest request) {
-        return findWebSocketRoute(request.getRequestPath()).getHandler();
+        return new JettyWebSocketAdapter(match.getHandler(), match.getPathParameters());
     }
 
 }

--- a/pippo-server-parent/pippo-jetty/src/main/java/ro/pippo/jetty/websocket/JettyWebSocketFilter.java
+++ b/pippo-server-parent/pippo-jetty/src/main/java/ro/pippo/jetty/websocket/JettyWebSocketFilter.java
@@ -94,7 +94,7 @@ public class JettyWebSocketFilter extends AbstractWebSocketFilter {
     }
 
     private WebSocketHandler getWebSocketHandler(ServletUpgradeRequest request) {
-        return getWebSocketHandler(request.getRequestPath());
+        return findWebSocketRoute(request.getRequestPath()).getHandler();
     }
 
 }

--- a/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/websocket/UndertowWebSocketAdapter.java
+++ b/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/websocket/UndertowWebSocketAdapter.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -49,12 +50,14 @@ public class UndertowWebSocketAdapter extends AbstractReceiveListener implements
     private static List<WebSocketConnection> connections = new CopyOnWriteArrayList<>();
 
     private final WebSocketHandler handler;
+    private final Map<String, String> pathParameters;
 
     private WebSocketContext context;
     private WebSocketConnection connection;
 
-    public UndertowWebSocketAdapter(WebSocketHandler handler) {
+    public UndertowWebSocketAdapter(WebSocketHandler handler, Map<String, String> pathParameters) {
         this.handler = handler;
+        this.pathParameters = pathParameters;
     }
 
     @Override
@@ -64,7 +67,7 @@ public class UndertowWebSocketAdapter extends AbstractReceiveListener implements
 
         connection = new UndertowWebSocketConnection(exchange, channel);
         connections.add(connection);
-        context = new WebSocketContext(connections, connection);
+        context = new WebSocketContext(connections, connection, pathParameters);
 
         handler.onOpen(context);
     }

--- a/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/websocket/UndertowWebSocketFilter.java
+++ b/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/websocket/UndertowWebSocketFilter.java
@@ -100,7 +100,7 @@ public class UndertowWebSocketFilter extends AbstractWebSocketFilter {
     }
 
     private WebSocketHandler getWebSocketHandler(Request request) {
-        return getWebSocketHandler(request.getUri());
+        return findWebSocketRoute(request.getUri()).getHandler();
     }
 
 }

--- a/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/websocket/UndertowWebSocketFilter.java
+++ b/pippo-server-parent/pippo-undertow/src/main/java/ro/pippo/undertow/websocket/UndertowWebSocketFilter.java
@@ -26,7 +26,7 @@ import ro.pippo.core.PippoRuntimeException;
 import ro.pippo.core.Request;
 import ro.pippo.core.Response;
 import ro.pippo.core.websocket.AbstractWebSocketFilter;
-import ro.pippo.core.websocket.WebSocketHandler;
+import ro.pippo.core.websocket.WebSocketRouter;
 
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
@@ -96,11 +96,9 @@ public class UndertowWebSocketFilter extends AbstractWebSocketFilter {
     }
 
     protected UndertowWebSocketAdapter createWebSocketAdapter(Request request) {
-        return new UndertowWebSocketAdapter(getWebSocketHandler(request));
-    }
+        WebSocketRouter.WebSocketMatch match = findWebSocketRoute(request.getUri());
 
-    private WebSocketHandler getWebSocketHandler(Request request) {
-        return findWebSocketRoute(request.getUri()).getHandler();
+        return new UndertowWebSocketAdapter(match.getHandler(), match.getPathParameters());
     }
 
 }


### PR DESCRIPTION
This PR contains a functional POC (prof of concept) for #395.
The code works but need some adjustment.

For Undertow:
```java
addWebSocket("/ws/chat/{room}", (webSocketContext, message) -> {
    WebSocketConnection connection = webSocketContext.getConnection();
    // cast WebSocketConnection to UndertowWebSocketConnection
    UndertowWebSocketConnection undertowConnection = (UndertowWebSocketConnection) connection;
    String remoteAddress = undertowConnection.getRemoteAddress().toString();
    System.out.println("remoteAddress = " + remoteAddress);
    WebSocketHttpExchange exchange = undertowConnection.getExchange();
    String query = exchange.getQueryString();
    System.out.println("query = " + query);
});
```

For Jetty the code is similar with the code presented in https://github.com/decebals/pippo/pull/360#issuecomment-296453997.

Also this PR comes with a hidden nice feature, `UriMatcher` with `DefaultUriMatcher`. So, the `DefaultRouter` was spitted in two parts.  It's more easy to implement a custom router with uri matcher (maybe some one wants another notation for path parameters or supply a more fast uri matching algorithm).

In `WebSocketContext` you will can access the parameters value (I have already these information), similar with the approach used in Request. Also, `WebSocketContext` will contain other information like session, request header.