### PR TITLE
Remove code duplication from ParameterValue

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java
+++ b/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java
@@ -240,15 +240,11 @@ public class ParameterValue implements Serializable {
     }
 
     public Set<String> toSet(Set<String> defaultValue) {
-        if (isNull() || (values.length == 1 && StringUtils.isNullOrEmpty(values[0]))) {
+        List<String> list = toList();
+        if (list.isEmpty()) {
             return defaultValue;
         }
-
-        if (values.length == 1) {
-            return new HashSet<>(Arrays.asList(values[0].split(",")));
-        }
-
-        return new HashSet<>(Arrays.asList(values));
+        return new HashSet<>(list);
     }
 
     /**

--- a/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
@@ -296,6 +296,14 @@ public class ParameterValueTest {
     }
 
     @Test
+    public void testEmptyArray() throws Exception {
+        // when parameterValue is empty
+        assertTrue(Arrays.equals(new int[0], new ParameterValue("").to(int[].class)));
+        // when parameterValue is null
+        assertTrue(Arrays.equals(new int[0], new ParameterValue().to(int[].class)));
+    }
+
+    @Test
     public void testEnums() throws Exception {
         assertNull(new ParameterValue(" ").toEnum(Alphabet.class));
         assertEquals(Alphabet.B, new ParameterValue("B").toEnum(Alphabet.class));

--- a/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/ParameterValueTest.java
@@ -223,6 +223,16 @@ public class ParameterValueTest {
     }
 
     @Test
+    public void testHashSet() throws Exception {
+        Set<String> mySet = new HashSet<>(Arrays.asList("200", "400", "600"));
+        assertEquals(mySet, new ParameterValue("600", "200", "400", "200").toSet());
+
+        // when values contains single entry
+        mySet = new HashSet<>(Arrays.asList("200"));
+        assertEquals(mySet, new ParameterValue("200").toSet());
+    }
+
+    @Test
     public void testStringTreeSet() throws Exception {
         TreeSet<String> mySet = new TreeSet<>(Arrays.asList("C", "B", "A"));
         assertEquals(mySet, new ParameterValue("C", "A", "B", "A").toCollection(TreeSet.class, String.class, null));


### PR DESCRIPTION
@decebals 

> Not related to this commit. Sharing it here instead of raising separate issue
```
https://github.com/decebals/pippo/blob/master/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java#L247
If values has single entry, 
toSet() handles it differently compared to toList(). Is there any reason for this behavior??

In toSet() method, value is split only on ,(comma) unlike toList(). I think, the behavior should be similar to toList(). 
```