### PR TITLE
Remove braces from start and end in getStrings

### DIFF
--- a/pippo-core/src/main/java/ro/pippo/core/PippoSettings.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoSettings.java
@@ -640,7 +640,7 @@ public class PippoSettings {
      * Returns a list of comma-delimited integers from the specified name.
      *
      * @param name
-     * @return list of strings
+     * @return list of integers
      */
     public List<Integer> getIntegers(String name) {
         return getIntegers(name, DEFAULT_LIST_DELIMITER);
@@ -672,7 +672,7 @@ public class PippoSettings {
      * Returns a list of comma-delimited longs from the specified name.
      *
      * @param name
-     * @return list of strings
+     * @return list of longs
      */
     public List<Long> getLongs(String name) {
         return getLongs(name, DEFAULT_LIST_DELIMITER);
@@ -698,6 +698,68 @@ public class PippoSettings {
         }
 
         return Collections.unmodifiableList(longs);
+    }
+
+    /**
+     * Returns a list of comma-delimited floats from the specified name.
+     *
+     * @param name
+     * @return list of floats
+     */
+    public List<Float> getFloats(String name) {
+        return getFloats(name, DEFAULT_LIST_DELIMITER);
+    }
+
+    /**
+     * Returns a list of floats from the specified name using the specified delimiter.
+     *
+     * @param name
+     * @param delimiter
+     * @return list of floats
+     */
+    public List<Float> getFloats(String name, String delimiter) {
+        List<String> strings = getStrings(name, delimiter);
+
+        List<Float> floats = new ArrayList<>(strings.size());
+        for (String value : strings) {
+            try {
+                float i = Float.parseFloat(value);
+                floats.add(i);
+            } catch (NumberFormatException e) {
+            }
+        }
+        return Collections.unmodifiableList(floats);
+    }
+
+    /**
+     * Returns a list of comma-delimited doubles from the specified name.
+     *
+     * @param name
+     * @return list of doubles
+     */
+    public List<Double> getDoubles(String name) {
+        return getDoubles(name, DEFAULT_LIST_DELIMITER);
+    }
+
+    /**
+     * Returns a list of doubles from the specified name using the specified delimiter.
+     *
+     * @param name
+     * @param delimiter
+     * @return list of doubles
+     */
+    public List<Double> getDoubles(String name, String delimiter) {
+        List<String> strings = getStrings(name, delimiter);
+
+        List<Double> doubles = new ArrayList<>(strings.size());
+        for (String value : strings) {
+            try {
+                double i = Double.parseDouble(value);
+                doubles.add(i);
+            } catch (NumberFormatException e) {
+            }
+        }
+        return Collections.unmodifiableList(doubles);
     }
 
     /**

--- a/pippo-core/src/main/java/ro/pippo/core/PippoSettings.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoSettings.java
@@ -627,6 +627,12 @@ public class PippoSettings {
         if (StringUtils.isNullOrEmpty(value)) {
             return Collections.emptyList();
         }
+
+        value = value.trim();
+        // to handles cases where value is specified like [a,b, c]
+        if (value.startsWith("[") && value.endsWith("]")) {
+            value = value.substring(1, value.length() - 1);
+        }
         return StringUtils.getList(value, delimiter);
     }
 

--- a/pippo-core/src/main/java/ro/pippo/core/PippoSettings.java
+++ b/pippo-core/src/main/java/ro/pippo/core/PippoSettings.java
@@ -493,7 +493,7 @@ public class PippoSettings {
         try {
             String value = getString(name, null);
             if (!StringUtils.isNullOrEmpty(value)) {
-                return Integer.parseInt(value.trim().split(" ")[0]);
+                return Integer.parseInt(value.trim());
             }
         } catch (NumberFormatException e) {
             log.warn("Failed to parse integer for " + name + USING_DEFAULT_OF
@@ -516,7 +516,7 @@ public class PippoSettings {
         try {
             String value = getString(name, null);
             if (!StringUtils.isNullOrEmpty(value)) {
-                return Long.parseLong(value.trim().split(" ")[0]);
+                return Long.parseLong(value.trim());
             }
         } catch (NumberFormatException e) {
             log.warn("Failed to parse long for " + name + USING_DEFAULT_OF
@@ -539,7 +539,7 @@ public class PippoSettings {
         try {
             String value = getString(name, null);
             if (!StringUtils.isNullOrEmpty(value)) {
-                return Float.parseFloat(value.trim().split(" ")[0]);
+                return Float.parseFloat(value.trim());
             }
         } catch (NumberFormatException e) {
             log.warn("Failed to parse float for " + name + USING_DEFAULT_OF
@@ -562,7 +562,7 @@ public class PippoSettings {
         try {
             String value = getString(name, null);
             if (!StringUtils.isNullOrEmpty(value)) {
-                return Double.parseDouble(value.trim().split(" ")[0]);
+                return Double.parseDouble(value.trim());
             }
         } catch (NumberFormatException e) {
             log.warn("Failed to parse double for " + name + USING_DEFAULT_OF
@@ -655,11 +655,8 @@ public class PippoSettings {
      */
     public List<Integer> getIntegers(String name, String delimiter) {
         List<String> strings = getStrings(name, delimiter);
-        if (strings.isEmpty()) {
-            return Collections.emptyList();
-        }
 
-        List<Integer> ints = new ArrayList<>();
+        List<Integer> ints = new ArrayList<>(strings.size());
         for (String value : strings) {
             try {
                 int i = Integer.parseInt(value);
@@ -690,11 +687,8 @@ public class PippoSettings {
      */
     public List<Long> getLongs(String name, String delimiter) {
         List<String> strings = getStrings(name, delimiter);
-        if (strings.isEmpty()) {
-            return Collections.emptyList();
-        }
 
-        List<Long> longs = new ArrayList<>();
+        List<Long> longs = new ArrayList<>(strings.size());
         for (String value : strings) {
             try {
                 long i = Long.parseLong(value);

--- a/pippo-core/src/test/java/ro/pippo/core/PippoSettingsTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/PippoSettingsTest.java
@@ -63,6 +63,22 @@ public class PippoSettingsTest {
     }
 
     @Test
+    public void testGetDoubles() {
+        // tests would similar for getFloats(String, String)
+        Mockito.doReturn(" [1234, 123, value3]").when(pippoSettings)
+            .getString("key", null);
+        Mockito.doCallRealMethod().when(pippoSettings).getStrings("key", ",");
+        Mockito.doCallRealMethod().when(pippoSettings).getDoubles("key", ",");
+
+        List<Double> values = pippoSettings.getDoubles("key", ",");
+        assertEquals(Arrays.asList(1234d, 123d), values);
+
+        Mockito.doReturn(Collections.emptyList()).when(pippoSettings).getStrings("key", ",");
+        values = pippoSettings.getDoubles("key", ",");
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
     public void testGetNumber() {
         Mockito.doReturn(" 1234").when(pippoSettings).getString("key", null);
         Mockito.doCallRealMethod().when(pippoSettings).getInteger("key", 0);

--- a/pippo-core/src/test/java/ro/pippo/core/PippoSettingsTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/PippoSettingsTest.java
@@ -61,4 +61,36 @@ public class PippoSettingsTest {
         values = pippoSettings.getIntegers("key", ",");
         assertTrue(values.isEmpty());
     }
+
+    @Test
+    public void testGetNumber() {
+        Mockito.doReturn(" 1234").when(pippoSettings).getString("key", null);
+        Mockito.doCallRealMethod().when(pippoSettings).getInteger("key", 0);
+        Mockito.doCallRealMethod().when(pippoSettings).getLong("key", 0);
+        Mockito.doCallRealMethod().when(pippoSettings).getFloat("key", 0.0f);
+        Mockito.doCallRealMethod().when(pippoSettings).getDouble("key", 2.4d);
+
+        int valueInt = pippoSettings.getInteger("key", 0);
+        long valueLong = pippoSettings.getLong("key", 0);
+        float valueFloat = pippoSettings.getFloat("key", 0.0f);
+        double valueDouble = pippoSettings.getDouble("key", 2.4d);
+
+        assertEquals(1234, valueInt);
+        assertEquals(1234L, valueLong);
+        assertEquals(Float.parseFloat("1234"), valueFloat, 0.0f);
+        assertEquals(Double.parseDouble("1234"), valueDouble, 0.0d);
+
+        // case when number followed by some char sequence
+        Mockito.doReturn(" 1234 abc").when(pippoSettings).getString("key", null);
+        valueInt = pippoSettings.getInteger("key", 0);
+        valueLong = pippoSettings.getLong("key", 0);
+        valueFloat = pippoSettings.getFloat("key", 0.0f);
+        valueDouble = pippoSettings.getDouble("key", 2.4d);
+
+        assertEquals(0, valueInt);
+        assertEquals(0L, valueLong);
+        assertEquals(0.0f, valueFloat, 0.0f);
+        assertEquals(2.4d, valueDouble, 0.0d);
+    }
+
 }

--- a/pippo-core/src/test/java/ro/pippo/core/PippoSettingsTest.java
+++ b/pippo-core/src/test/java/ro/pippo/core/PippoSettingsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.pippo.core;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PippoSettingsTest {
+
+    private PippoSettings pippoSettings = Mockito.mock(PippoSettings.class);
+
+    @Test
+    public void testGetStrings() {
+        Mockito.doReturn(" [value1, value2, value3]").when(pippoSettings)
+            .getString("key", null);
+        Mockito.doCallRealMethod().when(pippoSettings).getStrings("key", ",");
+
+        // using default delimiter, since it is private pass same as delimiter
+        List<String> values = pippoSettings.getStrings("key", ",");
+        assertEquals(Arrays.asList("value1","value2","value3"), values);
+
+        // when only closing bracket specified
+        Mockito.doReturn(" value1/value2/value3]").when(pippoSettings)
+            .getString("key", null);
+        Mockito.doCallRealMethod().when(pippoSettings).getStrings("key", "/");
+        values = pippoSettings.getStrings("key", "/");
+        assertEquals(Arrays.asList("value1","value2","value3]"), values);
+    }
+
+    @Test
+    public void testGetIntegers() {
+        Mockito.doReturn(" [1234, 123, value3]").when(pippoSettings)
+            .getString("key", null);
+        Mockito.doCallRealMethod().when(pippoSettings).getStrings("key", ",");
+        Mockito.doCallRealMethod().when(pippoSettings).getIntegers("key", ",");
+
+        List<Integer> values = pippoSettings.getIntegers("key", ",");
+        assertEquals(Arrays.asList(1234, 123), values);
+
+        Mockito.doReturn(Collections.emptyList()).when(pippoSettings).getStrings("key", ",");
+        values = pippoSettings.getIntegers("key", ",");
+        assertTrue(values.isEmpty());
+    }
+}


### PR DESCRIPTION
This would help the user to specify properties like below,
`key=[value1, value2, value3]` (more verbose)
Based on 
https://github.com/decebals/pippo/blob/master/pippo-core/src/main/java/ro/pippo/core/ParameterValue.java#L277